### PR TITLE
Fix DeepSeek V4 Flash Vision Metal inference and MTP

### DIFF
--- a/cpp_runtime/backends/metal/apps/mfq_decode_mlx.cpp
+++ b/cpp_runtime/backends/metal/apps/mfq_decode_mlx.cpp
@@ -323,10 +323,7 @@ std::size_t requested_cache_bytes(
                 "DeepSeek-V4 expert cache exceeds addressable memory");
         }
         const auto bytes = static_cast<std::size_t>(requested);
-        if (hf_streaming && bytes == 0) {
-            throw std::runtime_error(
-                "HF SSD expert streaming requires a non-zero cache");
-        }
+        // An explicit zero keeps native HF expert banks fully resident.
         return bytes;
     }
     if (!hf_streaming) {
@@ -337,6 +334,53 @@ std::size_t requested_cache_bytes(
     return std::max<std::size_t>(
         std::uint64_t{1} << 30,
         physical_memory_bytes() * 2 / 3);
+}
+
+std::size_t resident_hf_wired_limit_bytes(
+    const std::filesystem::path& model_root) {
+    constexpr std::size_t gib = std::size_t{1} << 30;
+    if (const char* value = std::getenv("MFQ_HF_RESIDENT_WIRED_GIB")) {
+        const auto requested = std::stoull(value);
+        if (requested > std::numeric_limits<std::size_t>::max() / gib) {
+            throw std::invalid_argument(
+                "resident HF wired limit exceeds addressable memory");
+        }
+        return static_cast<std::size_t>(requested) * gib;
+    }
+
+    std::size_t checkpoint_bytes = 0;
+    std::error_code error;
+    for (std::filesystem::directory_iterator entries(model_root, error), end;
+         !error && entries != end;
+         entries.increment(error)) {
+        if (!entries->is_regular_file(error) || error ||
+            entries->path().extension() != ".safetensors") {
+            continue;
+        }
+        const auto bytes = entries->file_size(error);
+        if (error || bytes > std::numeric_limits<std::size_t>::max() -
+                checkpoint_bytes) {
+            throw std::runtime_error(
+                "cannot size resident HF checkpoint for its wired budget");
+        }
+        checkpoint_bytes += static_cast<std::size_t>(bytes);
+    }
+    if (error || checkpoint_bytes == 0) {
+        throw std::runtime_error(
+            "cannot discover resident HF safetensor payload");
+    }
+    const auto memory = physical_memory_bytes();
+    const auto reserve = std::max<std::size_t>(32 * gib, memory / 4);
+    if (memory <= reserve || checkpoint_bytes > memory - reserve) {
+        throw std::runtime_error(
+            "resident HF checkpoint does not fit the safe UMA budget");
+    }
+    const auto headroom = std::max<std::size_t>(32 * gib, checkpoint_bytes / 8);
+    return std::min(
+        memory - reserve,
+        checkpoint_bytes > std::numeric_limits<std::size_t>::max() - headroom
+            ? memory - reserve
+            : checkpoint_bytes + headroom);
 }
 
 std::filesystem::path executable_path() {
@@ -1624,7 +1668,7 @@ int serve_loaded_runtime(
                                 ? 0.0
                                 : static_cast<double>(
                                       stats.position_accepted[position]) /
-                                      stats.position_drafted[position]);
+                                  stats.position_drafted[position]);
                     }
                     for (std::size_t depth = 0;
                          depth < stats.measured_depth_ms.size();
@@ -1694,6 +1738,11 @@ int run_native_hf_server(const Arguments& arguments) {
             config.max_position_embeddings));
     const auto expert_cache_bytes = requested_cache_bytes(
         arguments.expert_cache_gb, true);
+    std::size_t resident_wired_limit = 0;
+    if (expert_cache_bytes == 0) {
+        resident_wired_limit = resident_hf_wired_limit_bytes(arguments.mfq);
+        mlx::core::set_wired_limit(resident_wired_limit);
+    }
     constexpr std::size_t prefill_buffers_minimum =
         std::size_t{7} << 30;
     const bool prefill_overlap =
@@ -1703,8 +1752,15 @@ int run_native_hf_server(const Arguments& arguments) {
     mlx::core::set_default_stream(runtime_stream);
     const auto started = std::chrono::steady_clock::now();
     std::cout
-        << "Loading native-format DeepSeek-V4 HF weights with SSD expert "
-           "streaming on Apple UMA..."
+        << "Loading native-format DeepSeek-V4 HF weights on Apple UMA: "
+        << (expert_cache_bytes == 0
+                ? "fully resident"
+                : "SSD expert streaming")
+        << (resident_wired_limit == 0
+                ? ""
+                : " (wired budget GiB=" + std::to_string(
+                      static_cast<double>(resident_wired_limit) /
+                      static_cast<double>(std::uint64_t{1} << 30)) + ")")
         << std::endl;
     auto runtime = mfq::metal::MlxDeepseekV4CausalLm::load_hf(
         arguments.mfq,
@@ -1720,7 +1776,10 @@ int run_native_hf_server(const Arguments& arguments) {
     std::cout
         << "Loaded " << runtime.layer_count()
         << " DeepSeek-V4 layers in " << load_seconds << " s"
-        << " expert_backing=hf-safetensors-ssd"
+        << " expert_backing="
+        << (expert_cache_bytes == 0
+                ? "hf-native-resident"
+                : "hf-safetensors-ssd")
         << " expert_cache_gib="
         << static_cast<double>(runtime.expert_cache_limit_bytes()) / gib
         << " prefill_double_buffer="

--- a/cpp_runtime/backends/metal/benchmarks/mlx_mx_benchmark.cpp
+++ b/cpp_runtime/backends/metal/benchmarks/mlx_mx_benchmark.cpp
@@ -240,6 +240,65 @@ void benchmark_grouped_synthetic(
         << std::setprecision(6) << checksum << '\t' << maximum << '\n';
 }
 
+void benchmark_diagonal_synthetic(
+    int rows,
+    int output_per_group,
+    int input_size,
+    int groups,
+    int repetitions) {
+    require(
+        rows >= 2 && rows <= 6 &&
+            output_per_group > 0 && output_per_group % 8 == 0 &&
+            input_size > 0 && input_size % 256 == 0 &&
+            groups > 0,
+        "invalid synthetic diagonal MXFP8 geometry");
+    auto weight = MlxMxWeight::from_blob(
+        "MXFP8",
+        make_synthetic_mx_blob(
+            8,
+            output_per_group * groups,
+            input_size));
+    auto flat = make_input(input_size, rows * groups);
+    auto source = mlx::core::reshape(
+        std::move(flat),
+        Shape{1, rows, groups, input_size});
+    const auto execute = [&] {
+        return weight.grouped_row_matmul(source, groups);
+    };
+    auto result = execute();
+    mlx::core::eval(result);
+    for (int index = 0; index < 4; ++index) {
+        result = execute();
+        mlx::core::eval(result);
+    }
+    mlx::core::synchronize();
+    const auto started = Clock::now();
+    for (int index = 0; index < repetitions; ++index) {
+        result = execute();
+        mlx::core::eval(result);
+    }
+    mlx::core::synchronize();
+    const double mean_ms = milliseconds_since(started) / repetitions;
+    auto checked = mlx::core::contiguous(
+        mlx::core::astype(result, mlx::core::float32));
+    mlx::core::eval(checked);
+    double checksum = 0.0;
+    for (std::size_t index = 0; index < checked.size(); ++index) {
+        require(
+            std::isfinite(checked.data<float>()[index]),
+            "diagonal MXFP8 benchmark produced a non-finite value");
+        checksum += checked.data<float>()[index];
+    }
+    std::cout
+        << "MXFP8\tsynthetic_diagonal\t"
+        << rows << 'x' << groups << 'x' << input_size << 'x'
+        << output_per_group << '\t' << weight.packed_nbytes() << '\t'
+        << std::fixed << std::setprecision(3) << mean_ms << '\t'
+        << std::setprecision(1)
+        << static_cast<double>(weight.packed_nbytes()) / (mean_ms * 1.0e6)
+        << '\t' << std::setprecision(6) << checksum << "\t0\n";
+}
+
 array fallback_grouped(
     const MlxMxWeight& weight,
     const array& input,
@@ -306,6 +365,24 @@ void benchmark_grouped(
 
 int main(int argc, char** argv) {
     try {
+        if (argc >= 2 && std::string(argv[1]) == "--synthetic-diagonal") {
+            require(
+                argc == 7,
+                "usage: mfq-metal-mx-benchmark --synthetic-diagonal "
+                "REPETITIONS ROWS OUTPUT_PER_GROUP INPUT GROUPS");
+            const int repetitions = std::stoi(argv[2]);
+            require(repetitions > 0, "repetitions must be positive");
+            std::cout
+                << "dtype\ttensor\tshape\tpacked_bytes\tms\tGB/s\t"
+                   "checksum\tmax_abs\n";
+            benchmark_diagonal_synthetic(
+                std::stoi(argv[3]),
+                std::stoi(argv[4]),
+                std::stoi(argv[5]),
+                std::stoi(argv[6]),
+                repetitions);
+            return 0;
+        }
         if (argc >= 2 && std::string(argv[1]) == "--synthetic-grouped") {
             require(
                 argc == 8,

--- a/cpp_runtime/backends/metal/models/deepseek_v4/mlx_deepseek_v4_attention.cpp
+++ b/cpp_runtime/backends/metal/models/deepseek_v4/mlx_deepseek_v4_attention.cpp
@@ -1463,10 +1463,14 @@ MlxDeepseekV4LayerState::MlxDeepseekV4LayerState(
 
 struct MlxDeepseekV4LayerSpeculation {
     MlxDeepseekV4LayerState checkpoint;
-    std::optional<array> attention_input;
     int confirmed_tokens;
     int total_tokens;
     int start_position;
+    std::optional<array> local_kv;
+    std::optional<array> main_kv;
+    std::optional<array> main_gate;
+    std::optional<array> index_kv;
+    std::optional<array> index_gate;
 };
 
 MlxDeepseekV4LayerState
@@ -1518,7 +1522,6 @@ void MlxDeepseekV4LayerState::begin_speculative(
     speculative_ = std::make_shared<MlxDeepseekV4LayerSpeculation>(
         MlxDeepseekV4LayerSpeculation{
             snapshot(),
-            std::nullopt,
             confirmed_tokens,
             total_tokens,
             position_,
@@ -2001,7 +2004,8 @@ struct MlxDeepseekV4Attention::Impl {
     array output_projection(
         const array& value,
         const array& cosine,
-        const array& sine) const {
+        const array& sine,
+        std::vector<array>* debug_stages = nullptr) const {
         const int batch = value.shape(0);
         const int tokens = value.shape(1);
         const int groups = checked_int(
@@ -2046,7 +2050,7 @@ struct MlxDeepseekV4Attention::Impl {
                       sine,
                       head_dim,
                       rotary)
-            : components.wo_a.mx_weight_ref() && tokens == 1
+            : components.wo_a.mx_weight_ref() && tokens <= 6
             ? components.wo_a.mx_weight_ref()
                   ->grouped_row_matmul_inverse_rope(
                       grouped,
@@ -2077,6 +2081,9 @@ struct MlxDeepseekV4Attention::Impl {
                 tokens,
                 groups * rank,
             });
+        if (debug_stages != nullptr) {
+            debug_stages->push_back(low_rank);
+        }
         if (detail::component_profile_active()) {
             detail::profile_eval(
                 std::string("attention.r")
@@ -2085,6 +2092,9 @@ struct MlxDeepseekV4Attention::Impl {
                 low_rank);
         }
         auto result = components.wo_b(low_rank);
+        if (debug_stages != nullptr) {
+            debug_stages->push_back(result);
+        }
         if (detail::component_profile_active()) {
             detail::profile_eval(
                 std::string("attention.r")
@@ -2351,6 +2361,15 @@ array MlxDeepseekV4Attention::operator()(
     MlxDeepseekV4LayerState& state,
     int pos0,
     const MlxDeepseekV4ImageVisibility* visibility) const {
+    return (*this)(input, state, pos0, visibility, nullptr);
+}
+
+array MlxDeepseekV4Attention::operator()(
+    const array& input,
+    MlxDeepseekV4LayerState& state,
+    int pos0,
+    const MlxDeepseekV4ImageVisibility* visibility,
+    std::vector<array>* debug_stages) const {
     auto source = floating_contiguous(input);
     const auto& config = impl_->config;
     const int hidden = checked_int(
@@ -2387,15 +2406,16 @@ array MlxDeepseekV4Attention::operator()(
     }
     const int batch = source.shape(0);
     const int tokens = source.shape(1);
+    MlxDeepseekV4LayerSpeculation* speculation = nullptr;
     if (state.speculative_) {
         auto& transaction = *state.speculative_;
-        if (transaction.attention_input ||
+        if (transaction.local_kv ||
             transaction.start_position != pos0 ||
             transaction.total_tokens != tokens) {
             throw std::runtime_error(
                 "DeepSeek-V4 speculative attention transaction mismatch");
         }
-        transaction.attention_input = source;
+        speculation = &transaction;
     }
     if (visibility != nullptr &&
         (tokens == 1 || pos0 != 0 || visibility->max_image_tokens <= 0 ||
@@ -2425,6 +2445,12 @@ array MlxDeepseekV4Attention::operator()(
     auto q_rank = impl_->q_norm(
         projected.at(output++));
     auto kv = projected.at(output++);
+    if (debug_stages != nullptr) {
+        debug_stages->push_back(source);
+        debug_stages->push_back(projected.at(0));
+        debug_stages->push_back(kv);
+        debug_stages->push_back(q_rank);
+    }
     if (detail::component_profile_active()) {
         detail::profile_eval(
             profile_component("q_rank_norm"),
@@ -2433,6 +2459,9 @@ array MlxDeepseekV4Attention::operator()(
     auto q_projected = mlx::core::reshape(
         impl_->components.q_b(q_rank),
         Shape{batch, tokens, heads, head_dim});
+    if (debug_stages != nullptr) {
+        debug_stages->push_back(q_projected);
+    }
     if (detail::component_profile_active()) {
         detail::profile_eval(
             profile_component("q_b_projection"),
@@ -2476,6 +2505,13 @@ array MlxDeepseekV4Attention::operator()(
     // the RoPE channels verbatim and use this same fake-quantized KV for both
     // prefill and incremental cache writes.
     kv = deepseek_v4_kv_fp8_sim_prefix(kv, rotary);
+    if (speculation != nullptr) {
+        speculation->local_kv = kv;
+    }
+    if (debug_stages != nullptr) {
+        debug_stages->push_back(q);
+        debug_stages->push_back(kv);
+    }
     if (detail::component_profile_active()) {
         detail::profile_eval(
             profile_component("q_rms_rope"),
@@ -2491,6 +2527,10 @@ array MlxDeepseekV4Attention::operator()(
     if (impl_->ratio != 0) {
         auto main_kv = projected.at(output++);
         auto main_gate = projected.at(output++);
+        if (debug_stages != nullptr) {
+            debug_stages->push_back(main_kv);
+            debug_stages->push_back(main_gate);
+        }
         array index_kv = mlx::core::zeros(
             Shape{1},
             source.dtype());
@@ -2501,6 +2541,19 @@ array MlxDeepseekV4Attention::operator()(
             index_kv = projected.at(output++);
             index_gate = projected.at(output++);
             index_weights = projected.at(output++);
+            if (debug_stages != nullptr) {
+                debug_stages->push_back(index_kv);
+                debug_stages->push_back(index_gate);
+                debug_stages->push_back(index_weights);
+            }
+        }
+        if (speculation != nullptr) {
+            speculation->main_kv = main_kv;
+            speculation->main_gate = main_gate;
+            if (impl_->ratio == 4) {
+                speculation->index_kv = index_kv;
+                speculation->index_gate = index_gate;
+            }
         }
         const bool batch_prefill =
             tokens > 1 &&
@@ -2585,7 +2638,6 @@ array MlxDeepseekV4Attention::operator()(
         throw std::runtime_error(
             "DeepSeek-V4 projection group output mismatch");
     }
-
     if (
         detail::component_profile_active()
         && impl_->ratio != 0
@@ -2634,7 +2686,13 @@ array MlxDeepseekV4Attention::operator()(
     array unified = state.local_;
     std::optional<std::pair<array, array>> plan;
     std::optional<array> direct_decode;
-    if (tokens == 1) {
+    // DSpark verifier rows must use the same selected-attention arithmetic as
+    // ordinary one-token decoding.  Mixing the circular decode kernel here
+    // with the selected verifier kernel changes a few final FP16 bits; those
+    // differences compound through the transformer and lower MTP acceptance.
+    // The selected plan is compact for decode (actual history, rounded to 32),
+    // so this also avoids scanning the full sliding-window cache.
+    if (tokens == 1 && !config.has_dspark()) {
         const int slot = pos0 % window;
         auto local_index = mlx::core::full(
             Shape{batch, 1},
@@ -2784,6 +2842,9 @@ array MlxDeepseekV4Attention::operator()(
                   plan->first,
                   plan->second,
                   impl_->components.sinks);
+    if (debug_stages != nullptr) {
+        debug_stages->push_back(attended);
+    }
     if (detail::component_profile_active()) {
         if (direct_decode) {
             detail::profile_eval(
@@ -2806,7 +2867,8 @@ array MlxDeepseekV4Attention::operator()(
     auto result = impl_->output_projection(
         attended,
         cosine,
-        sine);
+        sine,
+        debug_stages);
     state.position_ += tokens;
     return result;
 }
@@ -2821,7 +2883,7 @@ void MlxDeepseekV4Attention::rollback_speculative(
     int accepted_tokens) const {
     auto transaction = std::move(state.speculative_);
     state.speculative_.reset();
-    if (!transaction || !transaction->attention_input) {
+    if (!transaction || !transaction->local_kv) {
         throw std::runtime_error(
             "DeepSeek-V4 speculative attention checkpoint is unavailable");
     }
@@ -2832,19 +2894,83 @@ void MlxDeepseekV4Attention::rollback_speculative(
             "DeepSeek-V4 speculative acceptance count is invalid");
     }
     const int keep = transaction->confirmed_tokens + accepted_tokens;
-    auto input = mlx::core::slice(
-        *transaction->attention_input,
-        Shape{0, 0, 0},
-        Shape{
-            transaction->attention_input->shape(0),
-            keep,
-            transaction->attention_input->shape(2),
-        });
     const int start = transaction->start_position;
     state.restore_snapshot(std::move(transaction->checkpoint));
-    // Only the architecture-specific compressed attention cache is rebuilt.
-    // Decoder blocks, routed experts, HC and the LM head are not replayed.
-    (void)(*this)(input, state, start, nullptr);
+    if (transaction->local_kv->ndim() != 3 ||
+        transaction->local_kv->shape(0) != state.batch() ||
+        transaction->local_kv->shape(1) < keep) {
+        throw std::runtime_error(
+            "DeepSeek-V4 speculative KV capture is malformed");
+    }
+
+    // The verifier has already computed every cache projection. Restore the
+    // checkpoint and commit the accepted prefix from those values directly;
+    // replaying attention across 43 layers makes partial acceptance dominate
+    // otherwise profitable MTP cycles.
+    const int batch = state.batch();
+    const int window = state.local_.shape(1);
+    auto local_values = slice_axis(
+        *transaction->local_kv, 1, 0, keep);
+    auto local_positions = mlx::core::remainder(
+        mlx::core::arange(
+            start,
+            start + keep,
+            1,
+            mlx::core::int32),
+        array(window, mlx::core::int32));
+    auto local_indices = mlx::core::broadcast_to(
+        mlx::core::reshape(local_positions, Shape{1, keep}),
+        Shape{batch, keep});
+    state.local_ = dsv4_cache_write_inplace(
+        state.local_,
+        mlx::core::astype(local_values, state.local_.dtype()),
+        local_indices);
+
+    if (impl_->ratio != 0) {
+        if (!state.main_ || !transaction->main_kv ||
+            !transaction->main_gate ||
+            transaction->main_kv->shape(1) < keep ||
+            transaction->main_gate->shape(1) < keep ||
+            (impl_->ratio == 4 &&
+             (!state.indexer_ || !transaction->index_kv ||
+              !transaction->index_gate ||
+              transaction->index_kv->shape(1) < keep ||
+              transaction->index_gate->shape(1) < keep))) {
+            throw std::runtime_error(
+                "DeepSeek-V4 speculative compressor capture is malformed");
+        }
+        for (int token = 0; token < keep; ++token) {
+            const int length = start + token + 1;
+            state.main_->update(
+                slice_axis(*transaction->main_kv, 1, token, token + 1),
+                slice_axis(*transaction->main_gate, 1, token, token + 1),
+                *impl_->components.main_ape,
+                *impl_->components.main_norm,
+                length,
+                impl_->pool_rope->first,
+                impl_->pool_rope->second,
+                0,
+                static_cast<float>(impl_->config.rms_eps));
+            if (impl_->ratio == 4) {
+                state.indexer_->update(
+                    slice_axis(*transaction->index_kv, 1, token, token + 1),
+                    slice_axis(*transaction->index_gate, 1, token, token + 1),
+                    *impl_->components.index_ape,
+                    *impl_->components.index_norm,
+                    length,
+                    impl_->pool_rope->first,
+                    impl_->pool_rope->second,
+                    impl_->config.fast_indexer() ? 2 : 0,
+                    static_cast<float>(impl_->config.rms_eps));
+            }
+        }
+        if (state.indexer_ &&
+            state.indexer_->pool_len() != state.main_->pool_len()) {
+            throw std::runtime_error(
+                "DeepSeek-V4 speculative pool lengths diverged");
+        }
+    }
+    state.position_ = start + keep;
 }
 
 int MlxDeepseekV4Attention::ratio() const noexcept {

--- a/cpp_runtime/backends/metal/models/deepseek_v4/mlx_deepseek_v4_attention.h
+++ b/cpp_runtime/backends/metal/models/deepseek_v4/mlx_deepseek_v4_attention.h
@@ -304,6 +304,13 @@ public:
         int pos0,
         const MlxDeepseekV4ImageVisibility* visibility) const;
 
+    mlx::core::array operator()(
+        const mlx::core::array& input,
+        MlxDeepseekV4LayerState& state,
+        int pos0,
+        const MlxDeepseekV4ImageVisibility* visibility,
+        std::vector<mlx::core::array>* debug_stages) const;
+
     void commit_speculative(
         MlxDeepseekV4LayerState& state) const noexcept;
     void rollback_speculative(

--- a/cpp_runtime/backends/metal/models/deepseek_v4/mlx_deepseek_v4_causal_lm.cpp
+++ b/cpp_runtime/backends/metal/models/deepseek_v4/mlx_deepseek_v4_causal_lm.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
@@ -733,6 +734,24 @@ array MlxDeepseekV4Layer::forward(
     int pos0,
     MlxDeepseekV4SsdPrefetchedLayer* prefetched,
     const MlxDeepseekV4ImageVisibility* visibility) const {
+    return forward(
+        hidden,
+        token_ids,
+        state,
+        pos0,
+        prefetched,
+        visibility,
+        nullptr);
+}
+
+array MlxDeepseekV4Layer::forward(
+    const array& hidden,
+    const array& token_ids,
+    MlxDeepseekV4LayerState& state,
+    int pos0,
+    MlxDeepseekV4SsdPrefetchedLayer* prefetched,
+    const MlxDeepseekV4ImageVisibility* visibility,
+    std::vector<array>* debug_stages) const {
     auto source = floating_contiguous(hidden);
     const int expected_hidden =
         checked_int(config_.hidden, "hidden size");
@@ -769,6 +788,9 @@ array MlxDeepseekV4Layer::forward(
         components_.attention_norm,
         attention_norm_);
     auto branch = attention_hc.reduced;
+    if (debug_stages != nullptr) {
+        debug_stages->push_back(branch);
+    }
     detail::profile_eval(
         "layer.attention_hc_pre_norm",
         branch);
@@ -776,7 +798,8 @@ array MlxDeepseekV4Layer::forward(
         branch,
         state,
         pos0,
-        visibility);
+        visibility,
+        debug_stages);
     auto result = attention_hc.packed_metadata.has_value()
         ? deepseek_v4_hc_post_packed(
               branch,
@@ -790,6 +813,9 @@ array MlxDeepseekV4Layer::forward(
     detail::profile_eval(
         "layer.attention_hc_post",
         result);
+    if (debug_stages != nullptr) {
+        debug_stages->push_back(result);
+    }
     if (routed_prefetch != nullptr) {
         // Attention has no dependency on the expert banks. Materialize it
         // while the SSD workers fill the alternating routed buffer.
@@ -805,6 +831,9 @@ array MlxDeepseekV4Layer::forward(
         components_.ffn_norm,
         ffn_norm_);
     branch = ffn_hc.reduced;
+    if (debug_stages != nullptr) {
+        debug_stages->push_back(branch);
+    }
     detail::profile_eval(
         "layer.ffn_hc_pre_norm",
         branch);
@@ -812,6 +841,10 @@ array MlxDeepseekV4Layer::forward(
         branch,
         token_ids,
         routed_prefetch);
+    if (debug_stages != nullptr) {
+        debug_stages->push_back(moe_branches.routed);
+        debug_stages->push_back(moe_branches.shared);
+    }
     auto output = ffn_hc.packed_metadata.has_value()
         ? deepseek_v4_hc_post_sum_packed(
               moe_branches.routed,
@@ -826,6 +859,9 @@ array MlxDeepseekV4Layer::forward(
     detail::profile_eval(
         "layer.ffn_hc_post",
         output);
+    if (debug_stages != nullptr) {
+        debug_stages->push_back(output);
+    }
     return output;
 }
 
@@ -999,14 +1035,16 @@ MlxDeepseekV4CausalLm MlxDeepseekV4CausalLm::load_hf(
                 "predictor.stage." + std::to_string(stage));
         }
     }
-    auto expert_cache =
-        std::make_shared<MlxDeepseekV4SsdExpertCache>(
+    std::shared_ptr<MlxDeepseekV4SsdExpertCache> expert_cache;
+    if (expert_cache_bytes > 0) {
+        expert_cache = std::make_shared<MlxDeepseekV4SsdExpertCache>(
             model_root,
             std::move(expert_prefixes),
             expert_cache_bytes,
             io_workers,
             prefill_overlap,
             static_cast<std::size_t>(config.n_experts));
+    }
     auto rope_base = deepseek_v4_yarn_tables(
         checked_int(config.qk_rope_head_dim, "rotary dimension"),
         context,
@@ -1247,11 +1285,13 @@ void MlxDeepseekV4CausalLm::append_state_arrays(
     }
 }
 
-void MlxDeepseekV4CausalLm::materialize_state(
-    const MlxDeepseekV4LayerState& state) const {
+void MlxDeepseekV4CausalLm::materialize_states(
+    const std::vector<MlxDeepseekV4LayerState>& states) const {
     std::vector<array> arrays;
-    arrays.reserve(11);
-    append_state_arrays(state, arrays);
+    arrays.reserve(states.size() * 8);
+    for (const auto& state : states) {
+        append_state_arrays(state, arrays);
+    }
     detail::eval_with_timing(std::move(arrays));
 }
 
@@ -1265,10 +1305,17 @@ void MlxDeepseekV4CausalLm::begin_speculative_target(
     }
     for (auto& state : states_) {
         state.begin_speculative(confirmed_tokens, total_tokens);
-        // The target cache uses in-place ring writes. Resolve each compact
-        // checkpoint before verification can overwrite those physical rows.
-        materialize_state(state.speculative_checkpoint());
     }
+    // The target cache uses in-place ring writes. Resolve every compact
+    // checkpoint in one MLX evaluation before verification can overwrite
+    // those physical rows. Evaluating layer by layer introduces 43 host/GPU
+    // synchronization points on DeepSeek-V4.
+    std::vector<array> checkpoints;
+    checkpoints.reserve(states_.size() * 8);
+    for (const auto& state : states_) {
+        append_state_arrays(state.speculative_checkpoint(), checkpoints);
+    }
+    detail::eval_with_timing(std::move(checkpoints));
 }
 
 void MlxDeepseekV4CausalLm::commit_speculative_target() noexcept {
@@ -1289,8 +1336,11 @@ void MlxDeepseekV4CausalLm::rollback_speculative_target(
     for (std::size_t index = 0; index < layers_.size(); ++index) {
         layers_[index].rollback_speculative(
             states_[index], accepted_tokens);
-        materialize_state(states_[index]);
     }
+    // Rollback rebuilds the accepted attention rows lazily. Materialize the
+    // complete cache transaction together rather than synchronizing once per
+    // decoder layer.
+    materialize_states(states_);
     cache_position_ -= draft_tokens - accepted_tokens;
 }
 
@@ -1347,7 +1397,9 @@ array MlxDeepseekV4CausalLm::forward_chunk(
     bool full_logits,
     const std::optional<array>& input_embeddings,
     const MlxDeepseekV4ImageVisibility* visibility,
-    array* dspark_hidden) {
+    array* dspark_hidden,
+    std::vector<array>* debug_layer_hiddens,
+    std::vector<array>* debug_layer0_stages) {
     if (cache_batch_ == 0 ||
         states_.size() != layers_.size() ||
         token_ids.ndim() != 2 ||
@@ -1406,6 +1458,11 @@ array MlxDeepseekV4CausalLm::forward_chunk(
         "model.embedding_broadcast",
         hidden_values);
     const bool bounded_prefill = tokens > 1;
+    const bool compact_resident_speculation =
+        bounded_prefill && tokens <= 6 && dspark_hidden != nullptr &&
+        visibility == nullptr && !expert_offload_ && !ssd_expert_cache_;
+    const bool materialize_each_layer =
+        bounded_prefill && !compact_resident_speculation;
     std::array<
         std::optional<MlxDeepseekV4SsdPrefetchedLayer>,
         2> routed_pipeline;
@@ -1526,9 +1583,13 @@ array MlxDeepseekV4CausalLm::forward_chunk(
                 states_[index],
                 pos0,
                 prefetched,
-                visibility);
+                visibility,
+                index == 6 ? debug_layer0_stages : nullptr);
+            if (debug_layer_hiddens != nullptr) {
+                debug_layer_hiddens->push_back(hidden_values);
+            }
             capture_target(index);
-            if (bounded_prefill) {
+            if (materialize_each_layer) {
                 // Hidden and cache branches share the layer projections.
                 std::vector<array> layer_outputs{hidden_values};
                 layer_outputs.reserve(12);
@@ -1581,11 +1642,12 @@ array MlxDeepseekV4CausalLm::forward_chunk(
     detail::profile_eval(
         "model.lm_head_cast",
         logits);
-    if (!bounded_prefill) {
-        // Decode owns one token and a bounded cache update per layer.  Keep
-        // the complete 43-layer graph lazy, then materialize logits and every
-        // updated cache array together.  Evaluating hidden/state after every
-        // layer fragmented one token into roughly 86 Metal synchronizations.
+    if (!materialize_each_layer) {
+        // Decode and compact resident speculative verification own a bounded
+        // cache update per layer. Keep the complete 43-layer graph lazy, then
+        // materialize logits and every updated cache array together. Per-layer
+        // evaluation otherwise fragments a 1..6-token verify into roughly 86
+        // Metal synchronizations and makes it slower than serial decode.
         std::vector<array> outputs{logits};
         const auto append_pool =
             [&outputs](const MlxDeepseekV4PoolState& pool) {
@@ -1868,10 +1930,12 @@ MlxDeepseekV4CausalLm::capture_text_session_state(
     state.layers.reserve(states_.size());
     for (const auto& layer : states_) {
         auto snapshot = layer.snapshot();
-        materialize_state(snapshot);
         state.bytes += deepseek_v4_layer_snapshot_nbytes(snapshot);
         state.layers.push_back(std::move(snapshot));
     }
+    // Submit every detached cache copy in one evaluation. Evaluating one
+    // layer at a time adds dozens of CPU/GPU synchronization points.
+    materialize_states(state.layers);
     return state;
 }
 
@@ -1893,8 +1957,8 @@ void MlxDeepseekV4CausalLm::restore_text_session_state(
             // saved session immutable while the restored runtime advances.
             states_[index].restore_snapshot(
                 state.layers[index].snapshot());
-            materialize_state(states_[index]);
         }
+        materialize_states(states_);
         cache_position_ = state.cache_position;
         cache_batch_ = state.cache_batch;
         stable_cache_tokens_ = state.tokens;
@@ -1916,6 +1980,16 @@ std::int32_t MlxDeepseekV4CausalLm::generate(
         prefill_callback,
     std::optional<std::size_t> stable_prefix_tokens,
     const MfqTokenConstraintPtr& token_constraint) {
+    MlxDeepseekV4PrefillCallback report_prefill;
+    if (prefill_callback) {
+        report_prefill = [prefill_callback](
+            std::size_t tokens,
+            double llm_ms,
+            double,
+            double) {
+            prefill_callback(tokens, llm_ms);
+        };
+    }
     return generate_impl(
         prompt,
         nullptr,
@@ -1924,7 +1998,7 @@ std::int32_t MlxDeepseekV4CausalLm::generate(
         callback,
         eos_token_ids,
         chunk_size,
-        prefill_callback,
+        report_prefill,
         stable_prefix_tokens,
         token_constraint);
 }
@@ -1936,7 +2010,7 @@ std::int32_t MlxDeepseekV4CausalLm::generate_multimodal(
     std::int32_t max_tokens,
     const MlxDeepseekV4TokenCallback& callback,
     const std::optional<std::vector<std::int64_t>>& eos_token_ids,
-    const std::function<void(std::size_t, double)>& prefill_callback,
+    const MlxDeepseekV4PrefillCallback& prefill_callback,
     const MfqTokenConstraintPtr& token_constraint) {
     return generate_impl(
         prompt,
@@ -1959,7 +2033,7 @@ std::int32_t MlxDeepseekV4CausalLm::generate_impl(
     const MlxDeepseekV4TokenCallback& callback,
     const std::optional<std::vector<std::int64_t>>& eos_token_ids,
     int chunk_size,
-    const std::function<void(std::size_t, double)>& prefill_callback,
+    const MlxDeepseekV4PrefillCallback& prefill_callback,
     std::optional<std::size_t> stable_prefix_tokens,
     const MfqTokenConstraintPtr& token_constraint) {
     if (prompt.empty()) {
@@ -2066,9 +2140,7 @@ std::int32_t MlxDeepseekV4CausalLm::generate_impl(
         // State allocation/zeroing is request setup. Keep it in TTFT while
         // materializing it before the model-evaluation prefill metric starts.
         reset_cache(1);
-        for (const auto& state : states_) {
-            materialize_state(state);
-        }
+        materialize_states(states_);
     }
 
     struct StableCacheRestore {
@@ -2164,7 +2236,8 @@ std::int32_t MlxDeepseekV4CausalLm::generate_impl(
 
     const std::size_t evaluated_prompt_tokens =
         prompt.size() - reused_tokens;
-    double prefill_evaluation_ms = 0.0;
+    double llm_prefill_evaluation_ms = 0.0;
+    double multimodal_prefill_evaluation_ms = 0.0;
     const bool profile_prefill =
         detail::component_profile_requested();
     detail::ComponentProfile prefill_component_profile;
@@ -2177,7 +2250,7 @@ std::int32_t MlxDeepseekV4CausalLm::generate_impl(
                 : nullptr);
         detail::ScopedMlxEvaluationTiming timing(
             prefill_callback
-                ? &prefill_evaluation_ms
+                ? &llm_prefill_evaluation_ms
                 : nullptr);
         const auto prefill_range = [&](std::size_t begin, std::size_t end) {
             if (!dspark_active) {
@@ -2226,12 +2299,17 @@ std::int32_t MlxDeepseekV4CausalLm::generate_impl(
         std::optional<array> stable_logits;
         array value = [&]() {
             if (multimodal) {
-                reset_cache(1);
-                for (const auto& state : states_) {
-                    materialize_state(state);
-                }
                 auto embeddings = vision_->embed_prompt(
                     prompt, *images, embedding_, activation_dtype_);
+                if (prefill_callback) {
+                    // Materialize the vision tower and aligner before the
+                    // language model consumes their output. MLX is lazy, so
+                    // without this boundary their work is incorrectly billed
+                    // to the first text layer's prompt evaluation.
+                    detail::ScopedMlxEvaluationTiming multimodal_timing(
+                        &multimodal_prefill_evaluation_ms);
+                    detail::eval_with_timing(embeddings);
+                }
                 auto visibility = deepseek_v4_image_visibility(
                     prompt,
                     config_.vocab,
@@ -2254,6 +2332,22 @@ std::int32_t MlxDeepseekV4CausalLm::generate_impl(
                 return output;
             }
             if (!retain_stable_prefix) {
+                // The server supplies the reusable chat-template prefix even
+                // when MTP cannot reuse its target-only cache snapshot. Keep
+                // the same prefill boundary while rebuilding DSpark context
+                // from scratch. Otherwise ordinary generation evaluates
+                // [stable prefix, request suffix] as two BF16/MoE batches but
+                // MTP evaluates one larger batch; the tiny shape-dependent
+                // difference can eventually flip a greedy token.
+                if (dspark_active && requested_stable_count > 0 &&
+                    requested_stable_count < prompt.size()) {
+                    auto prefix_logits = prefill_range(
+                        0, requested_stable_count);
+                    detail::eval_with_timing(prefix_logits);
+                    materialize_states(states_);
+                    return prefill_range(
+                        requested_stable_count, prompt.size());
+                }
                 return prefill_range(0, prompt.size());
             }
             if (reused_tokens < stable_count) {
@@ -2261,16 +2355,12 @@ std::int32_t MlxDeepseekV4CausalLm::generate_impl(
                     reused_tokens,
                     stable_count);
             }
-            for (const auto& state : states_) {
-                materialize_state(state);
-            }
+            materialize_states(states_);
             stable_restore.capture(prompt, stable_count);
             // Materialize every copy before evaluating the suffix. Otherwise
             // the lazy copy graph would still read arrays after the suffix or
             // decode kernels had modified them in place.
-            for (const auto& state : stable_restore.states()) {
-                materialize_state(state);
-            }
+            materialize_states(stable_restore.states());
             if (stable_count < prompt.size()) {
                 return prefill_range(
                     stable_count,
@@ -2287,6 +2377,19 @@ std::int32_t MlxDeepseekV4CausalLm::generate_impl(
             // eval calls accumulate above; this final eval adds only the
             // remaining output-head graph.
             detail::eval_with_timing(value);
+        }
+        if (dspark_active) {
+            // DSpark prompt K/V construction is part of prefill. Materialize
+            // it here so its lazy graph is neither hidden in the first draft
+            // cycle nor mistaken for decode work by the adaptive scheduler.
+            std::vector<array> rings;
+            rings.reserve(dspark_state->stages());
+            for (std::size_t stage = 0;
+                 stage < dspark_state->stages();
+                 ++stage) {
+                rings.push_back(dspark_state->ring(stage));
+            }
+            detail::eval_with_timing(std::move(rings));
         }
         return value;
     }();
@@ -2328,7 +2431,10 @@ std::int32_t MlxDeepseekV4CausalLm::generate_impl(
     if (prefill_callback) {
         prefill_callback(
             evaluated_prompt_tokens,
-            prefill_evaluation_ms);
+            llm_prefill_evaluation_ms,
+            multimodal_prefill_evaluation_ms,
+            llm_prefill_evaluation_ms +
+                multimodal_prefill_evaluation_ms);
     }
     MlxSampler sampler(sampling);
 

--- a/cpp_runtime/backends/metal/models/deepseek_v4/mlx_deepseek_v4_causal_lm.h
+++ b/cpp_runtime/backends/metal/models/deepseek_v4/mlx_deepseek_v4_causal_lm.h
@@ -24,6 +24,12 @@
 
 namespace mfq::metal {
 
+using MlxDeepseekV4PrefillCallback = std::function<void(
+    std::size_t prompt_tokens,
+    double llm_ms,
+    double multimodal_ms,
+    double model_ms)>;
+
 struct MlxDeepseekV4LayerComponents {
     MlxDeepseekV4Attention attention;
     MlxDeepseekV4Moe moe;
@@ -97,6 +103,15 @@ public:
         int pos0,
         MlxDeepseekV4SsdPrefetchedLayer* prefetched,
         const MlxDeepseekV4ImageVisibility* visibility) const;
+
+    mlx::core::array forward(
+        const mlx::core::array& hidden,
+        const mlx::core::array& token_ids,
+        MlxDeepseekV4LayerState& state,
+        int pos0,
+        MlxDeepseekV4SsdPrefetchedLayer* prefetched,
+        const MlxDeepseekV4ImageVisibility* visibility,
+        std::vector<mlx::core::array>* debug_stages) const;
 
     std::optional<MlxDeepseekV4SsdPrefetchedLayer>
     prefetch_routed(std::size_t rows) const {
@@ -272,7 +287,7 @@ public:
         const MlxDeepseekV4TokenCallback& callback = {},
         const std::optional<std::vector<std::int64_t>>&
             eos_token_ids = std::nullopt,
-        const std::function<void(std::size_t, double)>&
+        const MlxDeepseekV4PrefillCallback&
             prefill_callback = {},
         const MfqTokenConstraintPtr& token_constraint = {});
 
@@ -333,7 +348,9 @@ private:
         const std::optional<mlx::core::array>& input_embeddings =
             std::nullopt,
         const MlxDeepseekV4ImageVisibility* visibility = nullptr,
-        mlx::core::array* dspark_hidden = nullptr);
+        mlx::core::array* dspark_hidden = nullptr,
+        std::vector<mlx::core::array>* debug_layer_hiddens = nullptr,
+        std::vector<mlx::core::array>* debug_layer0_stages = nullptr);
     mlx::core::array prefill_impl(
         const mlx::core::array& token_ids,
         int chunk_size,
@@ -341,8 +358,8 @@ private:
         bool reset);
     mlx::core::array head(
         const mlx::core::array& hidden) const;
-    void materialize_state(
-        const MlxDeepseekV4LayerState& state) const;
+    void materialize_states(
+        const std::vector<MlxDeepseekV4LayerState>& states) const;
     void append_state_arrays(
         const MlxDeepseekV4LayerState& state,
         std::vector<mlx::core::array>& arrays) const;
@@ -361,7 +378,7 @@ private:
         const MlxDeepseekV4TokenCallback& callback,
         const std::optional<std::vector<std::int64_t>>& eos_token_ids,
         int chunk_size,
-        const std::function<void(std::size_t, double)>& prefill_callback,
+        const MlxDeepseekV4PrefillCallback& prefill_callback,
         std::optional<std::size_t> stable_prefix_tokens,
         const MfqTokenConstraintPtr& token_constraint);
 

--- a/cpp_runtime/backends/metal/models/deepseek_v4/mlx_deepseek_v4_dspark.cpp
+++ b/cpp_runtime/backends/metal/models/deepseek_v4/mlx_deepseek_v4_dspark.cpp
@@ -10,6 +10,8 @@
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
+#include <iostream>
 #include <limits>
 #include <stdexcept>
 #include <string>
@@ -26,6 +28,25 @@ using mlx::core::array;
 
 constexpr int kConnections = 4;
 constexpr int kHcProjectionWidth = 24;
+
+void trace_dspark_value(
+    std::string_view label,
+    const array& value) {
+    if (std::getenv("MFQ_MLX_MTP_TRACE") == nullptr) return;
+    auto floating = mlx::core::astype(value, mlx::core::float32);
+    auto nan_count = mlx::core::sum(mlx::core::astype(
+        mlx::core::isnan(floating), mlx::core::int32));
+    auto maximum = mlx::core::max(mlx::core::abs(mlx::core::where(
+        mlx::core::isnan(floating),
+        mlx::core::zeros_like(floating),
+        floating)));
+    mlx::core::eval(nan_count, maximum);
+    std::cout
+        << "mtp_value_trace name=" << label
+        << " nan=" << nan_count.item<std::int32_t>()
+        << " max_abs=" << maximum.item<float>()
+        << std::endl;
+}
 
 int checked_int(std::int64_t value, const char* label) {
     if (value <= 0 ||
@@ -518,6 +539,7 @@ struct MlxDeepseekV4DSpark::Impl {
         const int window = checked_int(config.sliding_window, "window");
         const int rotary = checked_int(config.qk_rope_head_dim, "rotary width");
         auto kv = stage.kv_norm(stage.components.attention.kv(main_x));
+        trace_dspark_value("context.kv_before_rope", kv);
         auto positions = mlx::core::arange(
             start_position,
             start_position + tokens,
@@ -526,7 +548,9 @@ struct MlxDeepseekV4DSpark::Impl {
         auto cosine = mlx::core::take(rope.first, positions, 0);
         auto sine = mlx::core::take(rope.second, positions, 0);
         kv = apply_tail_rope(kv, rotary, cosine, sine);
+        trace_dspark_value("context.kv_after_rope", kv);
         kv = deepseek_v4_kv_fp8_sim_prefix(kv, rotary);
+        trace_dspark_value("context.kv_after_fp8", kv);
         int retained = std::min(tokens, window);
         if (retained != tokens) {
             kv = slice_axis(kv, 1, tokens - retained, tokens);
@@ -574,6 +598,8 @@ struct MlxDeepseekV4DSpark::Impl {
         q = apply_tail_rope(q, rotary, cosine, sine);
         kv = apply_tail_rope(kv, rotary, cosine, sine);
         kv = deepseek_v4_kv_fp8_sim_prefix(kv, rotary);
+        trace_dspark_value("attention.q", q);
+        trace_dspark_value("attention.kv", kv);
         const int active = std::min(position, ring.shape(1));
         if (active <= 0) {
             throw std::runtime_error(
@@ -583,8 +609,10 @@ struct MlxDeepseekV4DSpark::Impl {
             {slice_axis(ring, 1, 0, active),
              mlx::core::astype(kv, ring.dtype())},
             1);
+        trace_dspark_value("attention.keys", keys);
         auto attended = full_attention(
             q, keys, stage.components.attention.sinks);
+        trace_dspark_value("attention.output", attended);
         attended = apply_tail_rope(
             attended, rotary, cosine, sine, true);
         const int group_input = heads * head_dim / groups;
@@ -612,6 +640,7 @@ struct MlxDeepseekV4DSpark::Impl {
             stage.components.hc_attention_scale,
             stage.components.hc_attention_base,
             stage.attention_norm);
+        trace_dspark_value("block.attention_input", attn_hc.reduced);
         auto attended = attention(
             attn_hc.reduced, stage, ring, position);
         auto result = deepseek_v4_hc_post(
@@ -619,6 +648,7 @@ struct MlxDeepseekV4DSpark::Impl {
             residual,
             attn_hc.post,
             attn_hc.combination);
+        trace_dspark_value("block.attention_result", result);
 
         residual = result;
         auto ffn_hc = hc_pre_norm(
@@ -627,14 +657,19 @@ struct MlxDeepseekV4DSpark::Impl {
             stage.components.hc_ffn_scale,
             stage.components.hc_ffn_base,
             stage.ffn_norm);
+        trace_dspark_value("block.ffn_input", ffn_hc.reduced);
         auto branches = stage.components.moe.forward_branches(
             ffn_hc.reduced, token_ids);
-        return deepseek_v4_hc_post_sum(
+        trace_dspark_value("block.ffn_routed", branches.routed);
+        trace_dspark_value("block.ffn_shared", branches.shared);
+        auto output = deepseek_v4_hc_post_sum(
             branches.routed,
             branches.shared,
             residual,
             ffn_hc.post,
             ffn_hc.combination);
+        trace_dspark_value("block.output", output);
+        return output;
     }
 
     array head_hidden(const array& hidden) const {
@@ -728,9 +763,13 @@ MlxDeepseekV4DSpark::load_if_present(
             MlxLinear::load(
                 model,
                 last + ".markov.output.weight"),
-            MlxLinear::load(
+            // The released DSpark implementation promotes this BF16 tensor
+            // to FP32 and evaluates the confidence dot product in FP32. A
+            // BF16/FP16 accumulation can overflow on valid hidden states and
+            // yields NaN acceptance probabilities for short text prompts.
+            MlxLinear(load_float(
                 model,
-                last + ".confidence.projection.weight"),
+                last + ".confidence.projection.weight")),
         },
         max_context,
         deepseek_v4_yarn_tables(
@@ -747,9 +786,9 @@ MlxDeepseekV4DSpark MlxDeepseekV4DSpark::load_hf(
     int max_context,
     std::shared_ptr<MlxDeepseekV4SsdExpertCache> expert_cache,
     std::size_t expert_layer_base) {
-    if (!config.has_dspark() || !expert_cache) {
+    if (!config.has_dspark()) {
         throw std::invalid_argument(
-            "DeepSeek-V4 HF DSpark requires config and SSD expert cache");
+            "DeepSeek-V4 HF DSpark requires predictor configuration");
     }
     std::vector<MlxDeepseekV4DSparkStageComponents> stages;
     stages.reserve(static_cast<std::size_t>(config.n_mtp_layers));
@@ -782,8 +821,8 @@ MlxDeepseekV4DSpark MlxDeepseekV4DSpark::load_hf(
                 last + ".markov.input.weight"),
             model.load_linear(
                 last + ".markov.output.weight"),
-            model.load_linear(
-                last + ".confidence.projection.weight"),
+            MlxLinear(float32_contiguous(model.load_dense(
+                last + ".confidence.projection.weight"))),
         },
         max_context,
         deepseek_v4_yarn_tables(
@@ -844,7 +883,21 @@ void MlxDeepseekV4DSpark::append_context(
         throw std::invalid_argument(
             "invalid DeepSeek-V4 DSpark context append");
     }
-    auto main_x = impl_->main_norm(impl_->main_projection(source));
+    trace_dspark_value("context.target_hidden", source);
+    // MXFP8 matmul otherwise converts BF16 target hiddens directly to FP16.
+    // The first token can legitimately exceed 32768. Bound each token before
+    // that conversion; the following RMS normalization makes a positive
+    // per-token scale immaterial while retaining the fast packed FP16 path.
+    auto floating_source = mlx::core::astype(source, mlx::core::float32);
+    auto source_scale = mlx::core::maximum(
+        mlx::core::max(mlx::core::abs(floating_source), -1, true) /
+            mlx::core::array(64.0f),
+        mlx::core::array(1.0f));
+    auto main_x = impl_->main_norm(impl_->main_projection(
+        mlx::core::astype(
+            floating_source / source_scale,
+            mlx::core::float16)));
+    trace_dspark_value("context.main_x", main_x);
     for (std::size_t stage = 0; stage < impl_->stages.size(); ++stage) {
         state.rings_[stage] = impl_->append_stage_context(
             main_x,
@@ -866,21 +919,28 @@ MlxDeepseekV4DSparkDraft MlxDeepseekV4DSpark::draft(
     }
     anchors = mlx::core::contiguous(anchors);
     const int requested = width == 0 ? block_size() : width;
+    // DSpark's attention over the draft block is intentionally non-causal.
+    // Earlier draft states therefore depend on every noise-filled slot in
+    // the checkpoint's fixed block, even when serving returns fewer drafts.
+    // Preserve that trained geometry and truncate only the head outputs.
+    const int physical_width = std::min(
+        block_size(),
+        impl_->maximum_context - state.position_);
     const int vocab = checked_int(impl_->config.vocab, "vocabulary size");
     const int hidden_size = checked_int(impl_->config.hidden, "hidden size");
     if (anchors.ndim() != 2 || anchors.shape(0) != state.batch() ||
         anchors.shape(1) != 1 || requested <= 0 ||
         requested > block_size() || state.position_ <= 0 ||
-        requested > impl_->maximum_context - state.position_ ||
+        requested > physical_width ||
         state.stages() != impl_->stages.size()) {
         throw std::invalid_argument("invalid DeepSeek-V4 DSpark draft input");
     }
-    auto draft_ids = requested == 1
+    auto draft_ids = physical_width == 1
         ? anchors
         : mlx::core::concatenate(
               {anchors,
                mlx::core::full(
-                   Shape{state.batch(), requested - 1},
+                   Shape{state.batch(), physical_width - 1},
                    static_cast<std::int32_t>(
                        impl_->config.dspark_noise_token_id),
                    mlx::core::int32)},
@@ -890,7 +950,8 @@ MlxDeepseekV4DSparkDraft MlxDeepseekV4DSpark::draft(
         mlx::core::broadcast_to(
             mlx::core::expand_dims(embedded, 2),
             Shape{
-                state.batch(), requested, kConnections, hidden_size}));
+                state.batch(), physical_width, kConnections, hidden_size}));
+    trace_dspark_value("embedding", hidden);
     for (std::size_t stage = 0; stage < impl_->stages.size(); ++stage) {
         hidden = impl_->block(
             hidden,
@@ -898,13 +959,15 @@ MlxDeepseekV4DSparkDraft MlxDeepseekV4DSpark::draft(
             impl_->stages[stage],
             state.rings_[stage],
             state.position_);
+        trace_dspark_value("stage." + std::to_string(stage), hidden);
     }
     auto head_hidden = impl_->head_hidden(hidden);
+    trace_dspark_value("head_hidden", head_hidden);
     auto base_logits = mlx::core::astype(
         impl_->output(impl_->output_norm(head_hidden)),
         mlx::core::float32);
     if (base_logits.shape() !=
-        Shape{state.batch(), requested, vocab}) {
+        Shape{state.batch(), physical_width, vocab}) {
         throw std::runtime_error("DSpark LM head shape mismatch");
     }
 
@@ -934,11 +997,15 @@ MlxDeepseekV4DSparkDraft MlxDeepseekV4DSpark::draft(
     auto token_values = mlx::core::concatenate(tokens, 1);
     auto logit_values = mlx::core::concatenate(logits, 1);
     auto markov_values = mlx::core::concatenate(markov_embeddings, 1);
+    auto returned_hidden = requested == physical_width
+        ? head_hidden
+        : slice_axis(head_hidden, 1, 0, requested);
     auto confidence = impl_->head_components.confidence(
-        mlx::core::concatenate({head_hidden, markov_values}, -1));
+        mlx::core::concatenate({returned_hidden, markov_values}, -1));
     confidence = mlx::core::reshape(
         confidence,
         Shape{state.batch(), requested});
+    trace_dspark_value("confidence", confidence);
     return {
         std::move(token_values),
         std::move(logit_values),

--- a/cpp_runtime/backends/metal/models/deepseek_v4/mlx_deepseek_v4_moe.cpp
+++ b/cpp_runtime/backends/metal/models/deepseek_v4/mlx_deepseek_v4_moe.cpp
@@ -2,12 +2,15 @@
 
 #include "mlx_eval_timing.h"
 #include "mlx_moe_ops.h"
+#include "mlx_ssd_expert_arena.h"
 
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <future>
+#include <iostream>
 #include <limits>
 #include <stdexcept>
 #include <string>
@@ -21,6 +24,45 @@ namespace {
 
 using mlx::core::Shape;
 using mlx::core::array;
+
+MlxDeepseekV4SsdExpertWeights load_resident_hf_experts(
+    const MlxHfTensorStore& model,
+    const DeepseekV4Config& config,
+    const std::string& prefix) {
+    const auto count = static_cast<std::size_t>(config.n_experts);
+    DeepseekV4NativeExpertStore store(
+        model.checkpoint().root(),
+        std::vector<std::string>{prefix},
+        count);
+    MlxDeepseekV4SsdExpertArena arena(count);
+    std::vector<DeepseekV4NativeExpertDestination> destinations;
+    destinations.reserve(count);
+    for (std::size_t expert = 0; expert < count; ++expert) {
+        destinations.push_back(arena.destination(expert));
+    }
+    const auto workers = std::min<std::size_t>(8, count);
+    std::vector<std::future<void>> reads;
+    reads.reserve(workers);
+    for (std::size_t worker = 0; worker < workers; ++worker) {
+        reads.push_back(std::async(std::launch::async, [&, worker] {
+            for (std::size_t expert = worker;
+                 expert < count;
+                 expert += workers) {
+                store.load_scatter(0, expert, destinations[expert]);
+            }
+        }));
+    }
+    for (auto& read : reads) {
+        read.get();
+    }
+    std::cout
+        << "Resident HF experts: " << prefix
+        << " experts=" << count
+        << " bytes=" << arena.nbytes()
+        << std::endl;
+    // The returned MLX arrays retain the four arena bank allocations.
+    return arena.slot_weights();
+}
 
 double current_thread_cpu_seconds() noexcept {
     timespec value{};
@@ -603,17 +645,24 @@ MlxDeepseekV4Moe MlxDeepseekV4Moe::load_named(
     std::size_t expert_cache_layer,
     const std::optional<array>& available) {
     config.validate();
-    if (prefix.empty() || !expert_cache) {
+    if (prefix.empty()) {
         throw std::invalid_argument(
-            "DeepSeek-V4 named HF MoE requires a prefix and SSD cache");
+            "DeepSeek-V4 named HF MoE requires a prefix");
     }
     const auto name = [&prefix](std::string_view suffix) {
         return prefix + "." + std::string(suffix);
     };
     std::optional<array> visual_bias;
     const auto visual_name = name("mlp.router.vision_bias");
-    if (model.checkpoint().tensors().contains(visual_name)) {
+    if (config.has_vision()) {
         visual_bias = model.load_dense(visual_name);
+    }
+    std::optional<MlxRoutedLinear> resident_gate_up;
+    std::optional<MlxRoutedLinear> resident_down;
+    if (!expert_cache) {
+        auto weights = load_resident_hf_experts(model, config, prefix);
+        resident_gate_up.emplace(std::move(weights.gate_up));
+        resident_down.emplace(std::move(weights.down));
     }
     return MlxDeepseekV4Moe(
         config,
@@ -621,10 +670,10 @@ MlxDeepseekV4Moe MlxDeepseekV4Moe::load_named(
         model.load_linear(name("mlp.shared_expert.gate.weight")),
         model.load_linear(name("mlp.shared_expert.up.weight")),
         model.load_linear(name("mlp.shared_expert.down.weight")),
+        std::move(resident_gate_up),
         std::nullopt,
         std::nullopt,
-        std::nullopt,
-        std::nullopt,
+        std::move(resident_down),
         nullptr,
         std::move(expert_cache),
         expert_cache_layer,
@@ -650,10 +699,6 @@ MlxDeepseekV4Moe MlxDeepseekV4Moe::load(
         throw std::out_of_range(
             "DeepSeek-V4 HF MoE layer index is out of range");
     }
-    if (!expert_cache) {
-        throw std::invalid_argument(
-            "DeepSeek-V4 HF MoE requires an SSD expert cache");
-    }
     const auto name = [layer](std::string_view suffix) {
         return DeepseekV4TensorNames::layer(layer, suffix);
     };
@@ -668,16 +713,26 @@ MlxDeepseekV4Moe MlxDeepseekV4Moe::load(
     if (config.has_vision()) {
         visual_router_bias = model.load_dense(name("mlp.router.vision_bias"));
     }
+    std::optional<MlxRoutedLinear> resident_gate_up;
+    std::optional<MlxRoutedLinear> resident_down;
+    if (!expert_cache) {
+        auto weights = load_resident_hf_experts(
+            model,
+            config,
+            "model.block." + std::to_string(layer));
+        resident_gate_up.emplace(std::move(weights.gate_up));
+        resident_down.emplace(std::move(weights.down));
+    }
     return MlxDeepseekV4Moe(
         config,
         model.load_linear(name("mlp.router.weight")),
         model.load_linear(name("mlp.shared_expert.gate.weight")),
         model.load_linear(name("mlp.shared_expert.up.weight")),
         model.load_linear(name("mlp.shared_expert.down.weight")),
+        std::move(resident_gate_up),
         std::nullopt,
         std::nullopt,
-        std::nullopt,
-        std::nullopt,
+        std::move(resident_down),
         nullptr,
         std::move(expert_cache),
         layer,
@@ -1053,13 +1108,17 @@ MlxDeepseekV4Moe::project_shared(
     if (
         grouped_shared_gate_up_.has_value()
         && fused_shared_swiglu_
-        && grouped_shared_gate_up_
-            ->supports_single_row_swiglu(input)
+        && (grouped_shared_gate_up_->supports_single_row_swiglu(input)
+            || grouped_shared_gate_up_->supports_small_m_swiglu(input))
     ) {
-        auto shared_hidden =
-            grouped_shared_gate_up_->single_row_swiglu(
-                input,
-                swiglu_limit);
+        auto shared_hidden = grouped_shared_gate_up_
+                ->supports_single_row_swiglu(input)
+            ? grouped_shared_gate_up_->single_row_swiglu(
+                  input,
+                  swiglu_limit)
+            : grouped_shared_gate_up_->small_m_swiglu(
+                  input,
+                  swiglu_limit);
         if (project_router) {
             return {
                 router_(input),

--- a/cpp_runtime/backends/metal/models/deepseek_v4/mlx_deepseek_v4_sparse.cpp
+++ b/cpp_runtime/backends/metal/models/deepseek_v4/mlx_deepseek_v4_sparse.cpp
@@ -299,7 +299,7 @@ const Kernel& topk_kernel() {
 const Kernel& prefill_plan_kernel() {
     static const auto kernel = make_kernel(
         "mfq_cpp_dsv4_prefill_plan",
-        {"topk"},
+        {"topk", "plan_params"},
         {"indices", "mask"},
         kPrefillPlanSource);
     return kernel;
@@ -308,7 +308,7 @@ const Kernel& prefill_plan_kernel() {
 const Kernel& visible_prefill_plan_kernel() {
     static const auto kernel = make_kernel(
         "mfq_cpp_dsv4_visible_prefill_plan",
-        {"topk", "left", "right"},
+        {"topk", "left", "right", "plan_params"},
         {"indices", "mask"},
         kVisiblePrefillPlanSource);
     return kernel;
@@ -1136,18 +1136,28 @@ std::pair<array, array> dsv4_build_prefill_plan(
     const int batch = selected_topk.shape(0);
     const int queries = selected_topk.shape(1);
     const int topk_count = selected_topk.shape(2);
+    if (queries > std::numeric_limits<int>::max() - local_history) {
+        throw std::invalid_argument(
+            "DSV4 prefill local width exceeds integer range");
+    }
+    const int local_width = std::min(
+        window,
+        local_history + queries);
     if (topk_count >
-        std::numeric_limits<int>::max() - window - 31) {
+        std::numeric_limits<int>::max() - local_width - 31) {
         throw std::invalid_argument(
             "DSV4 prefill plan width exceeds MLX limits");
     }
     const int selected =
-        ((window + topk_count + 31) / 32) * 32;
+        ((local_width + topk_count + 31) / 32) * 32;
     const int total = checked_product(
         {batch, queries, selected},
         "prefill plan size");
+    const array plan_params(
+        {query_offset, local_history, local_width, pool_len, ratio, window},
+        mlx::core::int32);
     auto outputs = prefill_plan_kernel()(
-        {selected_topk},
+        {selected_topk, plan_params},
         {
             Shape{batch, queries, selected},
             Shape{batch, queries, selected},
@@ -1163,11 +1173,6 @@ std::pair<array, array> dsv4_build_prefill_plan(
             {"M", queries},
             {"TOPK_COUNT", topk_count},
             {"SELECTED", selected},
-            {"QUERY_OFFSET", query_offset},
-            {"LOCAL_HISTORY", local_history},
-            {"POOL_LEN", pool_len},
-            {"RATIO", ratio},
-            {"WINDOW", window},
         },
         std::nullopt,
         false,
@@ -1218,8 +1223,11 @@ std::pair<array, array> dsv4_build_prefill_plan_visible(
     const int total = checked_product(
         {batch, queries, selected},
         "visible prefill plan size");
+    const array plan_params(
+        {query_offset, local_history, local_width, pool_len, ratio, window},
+        mlx::core::int32);
     auto outputs = visible_prefill_plan_kernel()(
-        {selected_topk, left_values, right_values},
+        {selected_topk, left_values, right_values, plan_params},
         {
             Shape{batch, queries, selected},
             Shape{batch, queries, selected},
@@ -1232,12 +1240,6 @@ std::pair<array, array> dsv4_build_prefill_plan_visible(
             {"M", queries},
             {"TOPK_COUNT", topk_count},
             {"SELECTED", selected},
-            {"LOCAL_WIDTH", local_width},
-            {"QUERY_OFFSET", query_offset},
-            {"LOCAL_HISTORY", local_history},
-            {"POOL_LEN", pool_len},
-            {"RATIO", ratio},
-            {"WINDOW", window},
         },
         std::nullopt,
         false,

--- a/cpp_runtime/backends/metal/models/deepseek_v4/mlx_deepseek_v4_sparse_kernels.inc
+++ b/cpp_runtime/backends/metal/models/deepseek_v4/mlx_deepseek_v4_sparse_kernels.inc
@@ -1078,21 +1078,28 @@ constexpr const char* kPrefillPlanSource = R"MFQ_METAL(
     uint slot = linear % uint(SELECTED);
     uint row = linear / uint(SELECTED);
     uint query = row % uint(M);
-    uint raw_length = uint(LOCAL_HISTORY + M);
+    uint query_offset = uint(plan_params[0]);
+    uint local_history = uint(plan_params[1]);
+    uint local_width = uint(plan_params[2]);
+    uint pool_len = uint(plan_params[3]);
+    uint ratio = uint(plan_params[4]);
+    uint window = uint(plan_params[5]);
+    uint raw_length = local_history + uint(M);
     int index = 0;
     bool valid = false;
-    if (slot < uint(WINDOW)) {
-        uint local_end = uint(LOCAL_HISTORY) + query + 1u;
-        uint local_count = min(uint(WINDOW), local_end);
+    if (slot < local_width) {
+        uint local_end = local_history + query + 1u;
+        uint local_count = min(window, local_end);
         if (slot < local_count) {
             index = int(local_end - local_count + slot);
             valid = true;
         }
-    } else if (slot < uint(WINDOW + TOPK_COUNT)) {
-        int pooled = topk[row * uint(TOPK_COUNT) + slot - uint(WINDOW)];
+    } else if (slot < local_width + uint(TOPK_COUNT)) {
+        int pooled = topk[
+            row * uint(TOPK_COUNT) + slot - local_width];
         uint visible = min(
-            uint(POOL_LEN),
-            (uint(QUERY_OFFSET) + query + 1u) / uint(RATIO)
+            pool_len,
+            (query_offset + query + 1u) / ratio
         );
         if (pooled >= 0 && uint(pooled) < visible) {
             index = int(raw_length) + pooled;
@@ -1111,28 +1118,34 @@ constexpr const char* kVisiblePrefillPlanSource = R"MFQ_METAL(
     uint slot = linear % uint(SELECTED);
     uint row = linear / uint(SELECTED);
     uint query = row % uint(M);
-    uint raw_length = uint(LOCAL_HISTORY + M);
+    int query_offset = plan_params[0];
+    int local_history = plan_params[1];
+    int local_width = plan_params[2];
+    int pool_len = plan_params[3];
+    int ratio = plan_params[4];
+    int window = plan_params[5];
+    uint raw_length = uint(local_history + int(M));
     int index = 0;
     bool valid = false;
-    if (slot < uint(LOCAL_WIDTH)) {
-        int absolute_query = QUERY_OFFSET + int(query);
-        int base = QUERY_OFFSET - LOCAL_HISTORY;
+    if (slot < uint(local_width)) {
+        int absolute_query = query_offset + int(query);
+        int base = query_offset - local_history;
         int left_count = max(left[row], 0);
         int right_count = max(right[row], 0);
-        int left_add = max(left_count - (WINDOW - 1), 0);
-        int start = max(base, absolute_query - (WINDOW - 1) - left_add);
-        int end = min(QUERY_OFFSET + M - 1, absolute_query + right_count);
+        int left_add = max(left_count - (window - 1), 0);
+        int start = max(base, absolute_query - (window - 1) - left_add);
+        int end = min(query_offset + int(M) - 1, absolute_query + right_count);
         int count = max(end - start + 1, 0);
         if (int(slot) < count) {
             index = start - base + int(slot);
             valid = true;
         }
-    } else if (slot < uint(LOCAL_WIDTH + TOPK_COUNT)) {
+    } else if (slot < uint(local_width + int(TOPK_COUNT))) {
         int pooled = topk[
-            row * uint(TOPK_COUNT) + slot - uint(LOCAL_WIDTH)];
+            row * uint(TOPK_COUNT) + slot - uint(local_width)];
         uint visible = min(
-            uint(POOL_LEN),
-            (uint(QUERY_OFFSET) + query + 1u) / uint(RATIO)
+            uint(pool_len),
+            uint(query_offset + int(query) + 1) / uint(ratio)
         );
         if (pooled >= 0 && uint(pooled) < visible) {
             index = int(raw_length) + pooled;
@@ -1479,8 +1492,14 @@ constexpr const char* kSparseAttentionDecodeSource = R"MFQ_METAL(
         bool valid = isfinite(mask_value)
             && cache_row >= 0
             && cache_row < int(MAX_SEQ);
-        uint safe_row = valid ? uint(cache_row) : 0u;
-        uint cache_base = (batch * uint(MAX_SEQ) + safe_row) * DIM;
+        // Circular M=1 has no iteration corresponding to selected-plan
+        // alignment padding. Skip those slots so verifier rows execute the
+        // identical online-softmax instruction sequence.
+        if (!valid) {
+            continue;
+        }
+        uint cache_base =
+            (batch * uint(MAX_SEQ) + uint(cache_row)) * DIM;
 
         float dot = 0.0f;
         for (uint item = 0u; item < VALUES_PER_LANE; ++item) {
@@ -1488,21 +1507,19 @@ constexpr const char* kSparseAttentionDecodeSource = R"MFQ_METAL(
             dot += q[query_base + dimension]
                 * float(kv[cache_base + dimension]);
         }
-        float score = simd_sum(dot);
-        score = valid ? score * params[0] + mask_value : -INFINITY;
+        float score = simd_sum(dot) * params[0];
+        if (mask_value != 0.0f) {
+            score += mask_value;
+        }
         float new_maximum = max(maximum, score);
         float old_scale = metal::fast::exp(maximum - new_maximum);
-        float new_scale = valid
-            ? metal::fast::exp(score - new_maximum)
-            : 0.0f;
+        float new_scale = metal::fast::exp(score - new_maximum);
         denominator = denominator * old_scale + new_scale;
         maximum = new_maximum;
 
         for (uint item = 0u; item < VALUES_PER_LANE; ++item) {
             uint dimension = lane + item * 32u;
-            float value = valid
-                ? float(kv[cache_base + dimension])
-                : 0.0f;
+            float value = float(kv[cache_base + dimension]);
             accumulators[item] =
                 accumulators[item] * old_scale + value * new_scale;
         }

--- a/cpp_runtime/backends/metal/ops/mlx_grouped_linear.cpp
+++ b/cpp_runtime/backends/metal/ops/mlx_grouped_linear.cpp
@@ -2223,18 +2223,16 @@ std::string make_direct_small_m_blockwise_source(
                 "        constexpr uint MX_BLOCKS = uint(K) / MX_BLOCK;\n"
                 "        for (uint block = k_lane; block < MX_BLOCKS;"
                 " block += K_LANES) {\n"
-                "            uint column_base = block * MX_BLOCK;\n";
+                "            uint column_base = block * MX_BLOCK;\n"
+                "            float mx_accumulators[ROWS];\n"
+                "            for (uint row = 0u; row < uint(ROWS); ++row) {\n"
+                "                mx_accumulators[row] = 0.0f;\n"
+                "            }\n";
             if (layout.bits == 4) {
                 source +=
-                    "            float scale = mfq_grouped_mx_e8m0("
-                    "mx_scales_" + suffix
-                    + "[output * MX_BLOCKS + block]);\n"
                     "            uint value_base = output * (uint(K) / 2u);\n";
             } else {
                 source +=
-                    "            float scale = mfq_grouped_mx_e8m0("
-                    "mx_scales_" + suffix
-                    + "[(output / 128u) * MX_BLOCKS + block]);\n"
                     "            uint value_base = output * uint(K);\n";
             }
             source +=
@@ -2246,7 +2244,7 @@ std::string make_direct_small_m_blockwise_source(
                     "                uint packed = uint(*(device const ushort*)("
                     "mx_values_" + suffix
                     + " + value_base + (column >> 1u)));\n"
-                    "                float4 weights = scale * float4(\n"
+                    "                float4 weights = float4(\n"
                     "                    mfq_grouped_mx_fp4(uchar(packed & 15u)),\n"
                     "                    mfq_grouped_mx_fp4(uchar((packed >> 4u) & 15u)),\n"
                     "                    mfq_grouped_mx_fp4(uchar((packed >> 8u) & 15u)),\n"
@@ -2256,7 +2254,7 @@ std::string make_direct_small_m_blockwise_source(
                     "                uchar4 codes = as_type<uchar4>("
                     "*(device const uint*)(mx_values_" + suffix
                     + " + value_base + column));\n"
-                    "                float4 weights = scale * float4(\n"
+                    "                float4 weights = float4(\n"
                     "                    mfq_grouped_mx_fp8(codes.x),\n"
                     "                    mfq_grouped_mx_fp8(codes.y),\n"
                     "                    mfq_grouped_mx_fp8(codes.z),\n"
@@ -2266,9 +2264,35 @@ std::string make_direct_small_m_blockwise_source(
                 "                for (uint row = 0u; row < uint(ROWS); ++row) {\n"
                 "                    half4 activation = *(device const half4*)(\n"
                 "                        x + row * uint(K) + column);\n"
-                "                    accumulators[row] += dot(\n"
-                "                        float4(activation), weights);\n"
+                "                    mx_accumulators[row] = fma(\n"
+                "                        float(activation.x), weights.x,\n"
+                "                        mx_accumulators[row]);\n"
+                "                    mx_accumulators[row] = fma(\n"
+                "                        float(activation.y), weights.y,\n"
+                "                        mx_accumulators[row]);\n"
+                "                    mx_accumulators[row] = fma(\n"
+                "                        float(activation.z), weights.z,\n"
+                "                        mx_accumulators[row]);\n"
+                "                    mx_accumulators[row] = fma(\n"
+                "                        float(activation.w), weights.w,\n"
+                "                        mx_accumulators[row]);\n"
                 "                }\n"
+                "            }\n"
+                "            float scale = mfq_grouped_mx_e8m0(";
+            if (layout.bits == 4) {
+                source +=
+                    "mx_scales_" + suffix
+                    + "[output * MX_BLOCKS + block]);\n";
+            } else {
+                source +=
+                    "mx_scales_" + suffix
+                    + "[(output / 128u) * MX_BLOCKS + block]);\n";
+            }
+            source +=
+                "            for (uint row = 0u; row < uint(ROWS); ++row) {\n"
+                "                accumulators[row] = fma(\n"
+                "                    scale, mx_accumulators[row],\n"
+                "                    accumulators[row]);\n"
                 "            }\n"
                 "        }\n";
         } else {
@@ -3892,7 +3916,10 @@ constexpr const char* kSingleRowMxfp8PairSwiglu = R"METAL(
     device const uchar* values = projection == 0u
         ? mx_values_0
         : mx_values_1;
-    float accumulator = 0.0f;
+    float accumulators[M];
+    for (uint row = 0u; row < uint(M); ++row) {
+        accumulators[row] = 0.0f;
+    }
 
     // Gate and Up occupy separate SIMD half-groups. Both halves visit the
     // same 128-column block at once: the 16 lanes in each half read one
@@ -3901,10 +3928,6 @@ constexpr const char* kSingleRowMxfp8PairSwiglu = R"METAL(
     for (uint block = 0u; block < BLOCKS; ++block) {
         uint column_base = block * BLOCK;
         uint column = column_base + k_lane * 8u;
-        activation4_t activation0 =
-            *(device const activation4_t*)(x + column);
-        activation4_t activation1 =
-            *(device const activation4_t*)(x + column + 4u);
         uchar4 code0 = *(device const uchar4*)(
             values + value_base + column);
         uchar4 code1 = *(device const uchar4*)(
@@ -3919,37 +3942,49 @@ constexpr const char* kSingleRowMxfp8PairSwiglu = R"METAL(
             float(fp8_lut[uint(code1.y)]),
             float(fp8_lut[uint(code1.z)]),
             float(fp8_lut[uint(code1.w)]));
-        float block_dot =
-            dot(float4(activation0), weight0)
-            + dot(float4(activation1), weight1);
         uchar scale = projection == 0u
             ? mx_scales_0[scale_base + block]
             : mx_scales_1[scale_base + block];
-        accumulator = fma(
-            mfq_grouped_mx_e8m0(scale),
-            block_dot,
-            accumulator);
+        float block_scale = mfq_grouped_mx_e8m0(scale);
+        for (uint row = 0u; row < uint(M); ++row) {
+            uint input_base = row * uint(K);
+            activation4_t activation0 =
+                *(device const activation4_t*)(x + input_base + column);
+            activation4_t activation1 = *(device const activation4_t*)(
+                x + input_base + column + 4u);
+            float block_dot =
+                dot(float4(activation0), weight0)
+                + dot(float4(activation1), weight1);
+            accumulators[row] = fma(
+                block_scale,
+                block_dot,
+                accumulators[row]);
+        }
     }
 
     // Each 16-lane half is an independent reduction tree. Only lanes 0 and
     // 16 are consumed, so shuffle-down traffic from inactive upper nodes
     // cannot cross-contaminate the two projection sums.
-    accumulator += simd_shuffle_down(accumulator, 8);
-    accumulator += simd_shuffle_down(accumulator, 4);
-    accumulator += simd_shuffle_down(accumulator, 2);
-    accumulator += simd_shuffle_down(accumulator, 1);
-    float gate = simd_shuffle(accumulator, 0u);
-    float up = simd_shuffle(accumulator, 16u);
-    if (lane == 0u && output_index < uint(OUT)) {
-        // Match the unfused MXFP8 GEMV activation-dtype boundary.
-        gate = float(activation_t(gate));
-        up = float(activation_t(up));
-        if (params[0] > 0.0f) {
-            gate = min(gate, params[0]);
-            up = clamp(up, -params[0], params[0]);
+    for (uint row = 0u; row < uint(M); ++row) {
+        float accumulator = accumulators[row];
+        accumulator += simd_shuffle_down(accumulator, 8);
+        accumulator += simd_shuffle_down(accumulator, 4);
+        accumulator += simd_shuffle_down(accumulator, 2);
+        accumulator += simd_shuffle_down(accumulator, 1);
+        float gate = simd_shuffle(accumulator, 0u);
+        float up = simd_shuffle(accumulator, 16u);
+        if (lane == 0u && output_index < uint(OUT)) {
+            // Match the unfused MXFP8 GEMV activation-dtype boundary.
+            gate = float(activation_t(gate));
+            up = float(activation_t(up));
+            if (params[0] > 0.0f) {
+                gate = min(gate, params[0]);
+                up = clamp(up, -params[0], params[0]);
+            }
+            float activated = gate / (1.0f + exp(-gate));
+            y[row * uint(OUT) + output_index] =
+                activation_t(activated * up);
         }
-        float activated = gate / (1.0f + exp(-gate));
-        y[output_index] = activation_t(activated * up);
     }
 )METAL";
 
@@ -4765,6 +4800,25 @@ bool MlxGroupedLinear::supports_single_row_swiglu(
             impl_->input_size);
 }
 
+bool MlxGroupedLinear::supports_small_m_swiglu(
+    const array& input) const noexcept {
+    if (!impl_->has_single_row_mxfp8_fast_path()
+        || impl_->direct_layouts.size() != 2
+        || impl_->direct_layouts[0].family != kFamilyMx
+        || impl_->direct_layouts[0].bits != 8
+        || impl_->direct_layouts[1].family != kFamilyMx
+        || impl_->direct_layouts[1].bits != 8
+        || input.ndim() == 0
+        || input.shape(-1) != impl_->input_size
+        || (input.dtype() != mlx::core::float16
+            && input.dtype() != mlx::core::bfloat16)) {
+        return false;
+    }
+    const auto rows = input.size() /
+        static_cast<std::size_t>(impl_->input_size);
+    return rows >= 2 && rows <= 6;
+}
+
 array MlxGroupedLinear::single_row_swiglu(
     const array& input,
     float limit) const {
@@ -4816,6 +4870,7 @@ array MlxGroupedLinear::single_row_swiglu(
             {
                 {"K", impl_->input_size},
                 {"OUT", impl_->output_sizes[0]},
+                {"M", 1},
             },
             std::nullopt,
             false,
@@ -4872,6 +4927,53 @@ array MlxGroupedLinear::single_row_swiglu(
         },
         {64, 1, 1},
         std::move(templates),
+        std::nullopt,
+        false,
+        {}).front();
+    return mlx::core::reshape(
+        std::move(result),
+        std::move(output_shape));
+}
+
+array MlxGroupedLinear::small_m_swiglu(
+    const array& input,
+    float limit) const {
+    if (!supports_small_m_swiglu(input)) {
+        throw MlxGroupedLinearUnsupported(
+            "grouped MXFP8 SwiGLU requires two through six FP16/BF16 rows");
+    }
+    if (!std::isfinite(limit) || limit < 0.0f) {
+        throw std::invalid_argument(
+            "grouped SwiGLU limit must be finite and non-negative");
+    }
+    const int rows = checked_int(
+        input.size() / static_cast<std::size_t>(impl_->input_size),
+        "MXFP8 SwiGLU row count");
+    Shape output_shape(
+        input.shape().begin(),
+        input.shape().end() - 1);
+    output_shape.push_back(impl_->output_sizes[0]);
+    auto source = mlx::core::contiguous(mlx::core::reshape(
+        input,
+        Shape{rows, impl_->input_size}));
+    const array params({limit}, mlx::core::float32);
+    auto inputs = impl_->direct_weight_inputs;
+    inputs.push_back(source);
+    inputs.push_back(params);
+    const auto workgroups =
+        (static_cast<std::size_t>(impl_->output_sizes[0]) + 3) / 4;
+    const auto grid = workgroups * 128;
+    auto result = single_row_mxfp8_pair_swiglu_kernel(source.dtype())(
+        inputs,
+        {Shape{rows, impl_->output_sizes[0]}},
+        {source.dtype()},
+        {checked_int(grid, "MXFP8 SwiGLU Metal grid"), 1, 1},
+        {128, 1, 1},
+        {
+            {"K", impl_->input_size},
+            {"OUT", impl_->output_sizes[0]},
+            {"M", rows},
+        },
         std::nullopt,
         false,
         {}).front();

--- a/cpp_runtime/backends/metal/ops/mlx_grouped_linear.h
+++ b/cpp_runtime/backends/metal/ops/mlx_grouped_linear.h
@@ -63,6 +63,14 @@ public:
     mlx::core::array single_row_swiglu(
         const mlx::core::array& input,
         float limit) const;
+
+    // MXFP8 verifier counterpart to single_row_swiglu. It retains the same
+    // two 16-lane reduction trees for each of M=2..6 independent rows.
+    bool supports_small_m_swiglu(
+        const mlx::core::array& input) const noexcept;
+    mlx::core::array small_m_swiglu(
+        const mlx::core::array& input,
+        float limit) const;
     std::vector<mlx::core::array> operator()(
         const mlx::core::array& input) const {
         return matmul(input);

--- a/cpp_runtime/backends/metal/ops/mlx_mx.cpp
+++ b/cpp_runtime/backends/metal/ops/mlx_mx.cpp
@@ -400,10 +400,170 @@ constexpr const char* kMxfp8Gemv = R"METAL(
     }
 )METAL";
 
-// Decode-only DeepSeek-V4 O-LoRA projection.  The output row selects its
-// diagonal input group, and inverse RoPE is applied while the activation is
-// in registers.  This avoids both the standalone de-rotation tensor and the
-// off-diagonal work of a generic multi-row matmul.
+// Short DSpark verifier blocks need the diagonal MultiLinear projection used
+// by DeepSeek-V4's O-LoRA output path.  The generic grouped-row fallback
+// dequantizes the complete MXFP8 matrix and launches one GEMM per group.  This
+// schedule instead keeps M=2..6 activation rows in registers and reuses each
+// packed weight byte across all of them.  Its 32-lane reduction and four
+// outputs per SIMD group match MLX's decode QMV arithmetic.
+//
+// Scheduling derived from oMLX 0.6.4 verify_qmv.py.
+// Copyright © 2026 Apple Inc.  Licensed under Apache-2.0.
+constexpr const char* kMxfp8GroupedSmallM = R"METAL(
+    constexpr uint VALUES_PER_THREAD = 8u;
+    constexpr uint K_BLOCK = VALUES_PER_THREAD * 32u;
+    constexpr uint OUTPUTS_PER_SIMD = 4u;
+    constexpr uint SIMD_GROUPS = 2u;
+    constexpr uint OUTPUTS_PER_TG = OUTPUTS_PER_SIMD * SIMD_GROUPS;
+    constexpr uint BLOCKS_PER_GROUP = uint(N) / OUTPUTS_PER_TG;
+
+    uint simd_group = simdgroup_index_in_threadgroup;
+    uint lane = thread_index_in_simdgroup;
+    uint flat_block = threadgroup_position_in_grid.y;
+    uint group = flat_block / BLOCKS_PER_GROUP;
+    uint group_block = flat_block - group * BLOCKS_PER_GROUP;
+    uint output_base =
+        group_block * OUTPUTS_PER_TG + simd_group * OUTPUTS_PER_SIMD;
+
+    device const uchar* weight_ptr = values
+        + (group * uint(N) + output_base) * uint(K)
+        + lane * VALUES_PER_THREAD;
+    device const half* input_ptr = x
+        + group * uint(M) * uint(K)
+        + lane * VALUES_PER_THREAD;
+    device half* output_ptr = y
+        + group * uint(M) * uint(N) + output_base;
+    // Expanded scales use the same per-output, 32-value layout passed to
+    // MLX quantized_matmul for the ordinary M=1 decode path.
+    device const uchar* scale_ptr = expanded_scales
+        + (group * uint(N) + output_base) * (uint(K) / 32u)
+        + lane / 4u;
+
+    float accum[M][OUTPUTS_PER_SIMD] = {{0.0f}};
+    for (uint k = 0u; k < uint(K); k += K_BLOCK) {
+        float input_values[M][VALUES_PER_THREAD];
+        for (uint row = 0u; row < uint(M); ++row) {
+            for (uint element = 0u;
+                 element < VALUES_PER_THREAD;
+                 ++element) {
+                input_values[row][element] =
+                    float(input_ptr[row * uint(K) + element]);
+            }
+        }
+        for (uint result = 0u;
+             result < OUTPUTS_PER_SIMD;
+             ++result) {
+            device const uchar* row_weight =
+                weight_ptr + result * uint(K);
+            device const uchar* row_scale =
+                scale_ptr + result * (uint(K) / 32u);
+            float scale = mfq_mx_e8m0(row_scale[0]);
+            for (uint row = 0u; row < uint(M); ++row) {
+                float dot_value = 0.0f;
+                for (uint element = 0u;
+                     element < VALUES_PER_THREAD;
+                     ++element) {
+                    dot_value += input_values[row][element]
+                        * mfq_mx_fp8(row_weight[element]);
+                }
+                accum[row][result] += scale * dot_value;
+            }
+        }
+        weight_ptr += K_BLOCK;
+        scale_ptr += K_BLOCK / 32u;
+        input_ptr += K_BLOCK;
+    }
+
+    for (uint row = 0u; row < uint(M); ++row) {
+        for (uint result = 0u;
+             result < OUTPUTS_PER_SIMD;
+             ++result) {
+            float value = simd_sum(accum[row][result]);
+            if (lane == 0u) {
+                output_ptr[row * uint(N) + result] = half(value);
+            }
+        }
+    }
+)METAL";
+
+// Non-grouped form of the same decode-exact verifier QMV.  Keeping a full
+// 32-lane reduction is required for row zero of a verifier batch to match an
+// ordinary MLX qmv_fast call bit for bit.
+constexpr const char* kMxfp8SmallMExact = R"METAL(
+    constexpr uint VALUES_PER_THREAD = 8u;
+    constexpr uint K_BLOCK = VALUES_PER_THREAD * 32u;
+    constexpr uint OUTPUTS_PER_SIMD = 4u;
+    constexpr uint SIMD_GROUPS = 2u;
+    constexpr uint OUTPUTS_PER_TG = OUTPUTS_PER_SIMD * SIMD_GROUPS;
+
+    uint simd_group = simdgroup_index_in_threadgroup;
+    uint lane = thread_index_in_simdgroup;
+    uint output_base =
+        threadgroup_position_in_grid.y * OUTPUTS_PER_TG
+        + simd_group * OUTPUTS_PER_SIMD;
+    if (output_base >= uint(N)) {
+        return;
+    }
+
+    device const uchar* weight_ptr = values
+        + output_base * uint(K) + lane * VALUES_PER_THREAD;
+    device const half* input_ptr = x + lane * VALUES_PER_THREAD;
+    device half* output_ptr = y + output_base;
+    device const uchar* scale_ptr = expanded_scales
+        + output_base * (uint(K) / 32u) + lane / 4u;
+
+    float accum[M][OUTPUTS_PER_SIMD] = {{0.0f}};
+    for (uint k = 0u; k < uint(K); k += K_BLOCK) {
+        float input_values[M][VALUES_PER_THREAD];
+        for (uint row = 0u; row < uint(M); ++row) {
+            for (uint element = 0u;
+                 element < VALUES_PER_THREAD;
+                 ++element) {
+                input_values[row][element] =
+                    float(input_ptr[row * uint(K) + element]);
+            }
+        }
+        for (uint result = 0u;
+             result < OUTPUTS_PER_SIMD;
+             ++result) {
+            device const uchar* row_weight =
+                weight_ptr + result * uint(K);
+            device const uchar* row_scale =
+                scale_ptr + result * (uint(K) / 32u);
+            float scale = mfq_mx_e8m0(row_scale[0]);
+            for (uint row = 0u; row < uint(M); ++row) {
+                float dot_value = 0.0f;
+                for (uint element = 0u;
+                     element < VALUES_PER_THREAD;
+                     ++element) {
+                    dot_value += input_values[row][element]
+                        * mfq_mx_fp8(row_weight[element]);
+                }
+                accum[row][result] += scale * dot_value;
+            }
+        }
+        weight_ptr += K_BLOCK;
+        scale_ptr += K_BLOCK / 32u;
+        input_ptr += K_BLOCK;
+    }
+
+    for (uint row = 0u; row < uint(M); ++row) {
+        for (uint result = 0u;
+             result < OUTPUTS_PER_SIMD;
+             ++result) {
+            float value = simd_sum(accum[row][result]);
+            if (lane == 0u) {
+                output_ptr[row * uint(N) + result] = half(value);
+            }
+        }
+    }
+)METAL";
+
+// DeepSeek-V4 O-LoRA projection for decode and short DSpark verifier blocks.
+// The output row selects its diagonal input group, and inverse RoPE is
+// applied while M=1..6 activation rows are in registers. Keeping the same
+// eight K lanes, FP16 RoPE boundary, FMA order, and shuffle tree for every M
+// makes verifier output bit-identical to ordinary one-token decode.
 constexpr const char* kMxfp8GroupedInverseRope = R"METAL(
     constexpr uint SIMD_GROUPS = 4u;
     constexpr uint K_LANES = 8u;
@@ -433,39 +593,20 @@ constexpr const char* kMxfp8GroupedInverseRope = R"METAL(
     uint input_group = output / uint(OUT_PER_GROUP);
     uint value_base = output * uint(K);
     uint scale_base = (output / BLOCK) * BLOCKS;
-    uint input_base = input_group * uint(K);
-    float accumulator = 0.0f;
+    float accumulators[M];
+    for (uint row = 0u; row < uint(M); ++row) {
+        accumulators[row] = 0.0f;
+    }
 
     for (uint block = k_lane; block < BLOCKS; block += K_LANES) {
         uint column_base = block * BLOCK;
-        float block_dot = 0.0f;
+        float block_dots[M];
+        for (uint row = 0u; row < uint(M); ++row) {
+            block_dots[row] = 0.0f;
+        }
         for (uint element = 0u; element < BLOCK; element += 4u) {
             uint column = column_base + element;
-            half4 source = *(device const half4*)(
-                x + input_base + column);
-            float4 activation = float4(source);
             uint head_column = column % uint(HEAD_DIM);
-            if (head_column >= PREFIX) {
-                uint pair = (head_column - PREFIX) >> 1u;
-                float cosine0 = float(cos_values[pair]);
-                float sine0 = float(sin_values[pair]);
-                float cosine1 = float(cos_values[pair + 1u]);
-                float sine1 = float(sin_values[pair + 1u]);
-                // Preserve the original graph's FP16 inverse-RoPE boundary.
-                half rotated0 = half(
-                    activation.x * cosine0 + activation.y * sine0);
-                half rotated1 = half(
-                    activation.y * cosine0 - activation.x * sine0);
-                half rotated2 = half(
-                    activation.z * cosine1 + activation.w * sine1);
-                half rotated3 = half(
-                    activation.w * cosine1 - activation.z * sine1);
-                activation = float4(
-                    float(rotated0),
-                    float(rotated1),
-                    float(rotated2),
-                    float(rotated3));
-            }
             uchar4 code = *(device const uchar4*)(
                 values + value_base + column);
             float4 weight = float4(
@@ -473,19 +614,55 @@ constexpr const char* kMxfp8GroupedInverseRope = R"METAL(
                 float(fp8_lut[uint(code.y)]),
                 float(fp8_lut[uint(code.z)]),
                 float(fp8_lut[uint(code.w)]));
-            block_dot += dot(activation, weight);
+            for (uint row = 0u; row < uint(M); ++row) {
+                uint input_base =
+                    (row * uint(GROUP_COUNT) + input_group) * uint(K);
+                half4 source = *(device const half4*)(
+                    x + input_base + column);
+                float4 activation = float4(source);
+                if (head_column >= PREFIX) {
+                    uint pair = (head_column - PREFIX) >> 1u;
+                    uint rope_base = row * PAIRS + pair;
+                    float cosine0 = float(cos_values[rope_base]);
+                    float sine0 = float(sin_values[rope_base]);
+                    float cosine1 = float(cos_values[rope_base + 1u]);
+                    float sine1 = float(sin_values[rope_base + 1u]);
+                    // Preserve the original graph's FP16 inverse-RoPE
+                    // boundary before the MXFP8 dot product.
+                    half rotated0 = half(
+                        activation.x * cosine0 + activation.y * sine0);
+                    half rotated1 = half(
+                        activation.y * cosine0 - activation.x * sine0);
+                    half rotated2 = half(
+                        activation.z * cosine1 + activation.w * sine1);
+                    half rotated3 = half(
+                        activation.w * cosine1 - activation.z * sine1);
+                    activation = float4(
+                        float(rotated0),
+                        float(rotated1),
+                        float(rotated2),
+                        float(rotated3));
+                }
+                block_dots[row] += dot(activation, weight);
+            }
         }
-        accumulator = fma(
-            mfq_mx_e8m0(scales[scale_base + block]),
-            block_dot,
-            accumulator);
+        float scale = mfq_mx_e8m0(scales[scale_base + block]);
+        for (uint row = 0u; row < uint(M); ++row) {
+            accumulators[row] = fma(
+                scale,
+                block_dots[row],
+                accumulators[row]);
+        }
     }
 
-    accumulator += simd_shuffle_down(accumulator, 4);
-    accumulator += simd_shuffle_down(accumulator, 2);
-    accumulator += simd_shuffle_down(accumulator, 1);
-    if (k_lane == 0u && output_index < uint(OUT)) {
-        y[output_index] = half(accumulator);
+    for (uint row = 0u; row < uint(M); ++row) {
+        float accumulator = accumulators[row];
+        accumulator += simd_shuffle_down(accumulator, 4);
+        accumulator += simd_shuffle_down(accumulator, 2);
+        accumulator += simd_shuffle_down(accumulator, 1);
+        if (k_lane == 0u && output_index < uint(OUT)) {
+            y[row * uint(OUT) + output_index] = half(accumulator);
+        }
     }
 )METAL";
 
@@ -556,6 +733,42 @@ const mlx::core::fast::CustomKernelFunction& mx_gemv_kernel() {
 const mlx::core::fast::CustomKernelFunction& mxfp8_gemv_kernel() {
     static const auto kernel = make_kernel(
         "mfq_cpp_mxfp8_block_gemv", kMxfp8Gemv);
+    return kernel;
+}
+
+const mlx::core::fast::CustomKernelFunction&
+mxfp8_grouped_small_m_kernel() {
+    static const auto kernel = [] {
+        CompileOptions options;
+        options.math_mode = MathMode::Fast;
+        return mlx::core::fast::metal_kernel(
+            "mfq_cpp_mxfp8_grouped_small_m_m2_6",
+            {"values", "expanded_scales", "x"},
+            {"y"},
+            kMxfp8GroupedSmallM,
+            kMxHeader,
+            true,
+            false,
+            options);
+    }();
+    return kernel;
+}
+
+const mlx::core::fast::CustomKernelFunction&
+mxfp8_small_m_exact_kernel() {
+    static const auto kernel = [] {
+        CompileOptions options;
+        options.math_mode = MathMode::Fast;
+        return mlx::core::fast::metal_kernel(
+            "mfq_cpp_mxfp8_small_m_exact_m2_6",
+            {"values", "expanded_scales", "x"},
+            {"y"},
+            kMxfp8SmallMExact,
+            kMxHeader,
+            true,
+            false,
+            options);
+    }();
     return kernel;
 }
 
@@ -810,6 +1023,35 @@ array MlxMxWeight::matmul(const array& input) const {
             "mxfp8");
         return mlx::core::reshape(std::move(result), std::move(output_shape));
     }
+    const auto* mxfp8_small_m_layout =
+        std::getenv("MFQ_METAL_MXFP8_SMALL_M_LAYOUT");
+    const bool exact_mxfp8_small_m =
+        rows >= 2 && rows <= 6 && bits_ == 8 &&
+        source.dtype() == mlx::core::float16 &&
+        expanded_mxfp8_scales_.has_value() &&
+        input_size_ % 512 == 0 && output_size_ >= 8 &&
+        output_size_ % 8 == 0 &&
+        (mxfp8_small_m_layout == nullptr ||
+         std::strcmp(mxfp8_small_m_layout, "legacy") != 0);
+    if (exact_mxfp8_small_m) {
+        auto outputs = mxfp8_small_m_exact_kernel()(
+            {values_, *expanded_mxfp8_scales_, std::move(source)},
+            {Shape{static_cast<int>(rows), output_size_}},
+            {mlx::core::float16},
+            {32, output_size_ / 4, 1},
+            {32, 2, 1},
+            {
+                {"M", static_cast<int>(rows)},
+                {"K", input_size_},
+                {"N", output_size_},
+            },
+            std::nullopt,
+            false,
+            {});
+        return mlx::core::reshape(
+            std::move(outputs.front()),
+            std::move(output_shape));
+    }
     if (rows >= 64) {
         auto dense = dequantize(source.dtype());
         auto result = mlx::core::matmul(source, mlx::core::transpose(dense));
@@ -910,6 +1152,70 @@ array MlxMxWeight::grouped_row_matmul(
             mlx::core::float16);
     }
     const int output_per_group = output_size_ / group_count;
+    std::size_t rows = 1;
+    for (std::size_t axis = 0; axis + 2 < source.ndim(); ++axis) {
+        rows *= static_cast<std::size_t>(source.shape(axis));
+    }
+    const auto* layout = std::getenv(
+        "MFQ_METAL_MXFP8_GROUPED_SMALL_M_LAYOUT");
+    const bool use_exact_small_m =
+        rows >= 2 && rows <= 6 &&
+        source.dtype() == mlx::core::float16 &&
+        expanded_mxfp8_scales_.has_value() &&
+        input_size_ % 256 == 0 &&
+        output_per_group % 8 == 0 &&
+        (layout == nullptr || std::strcmp(layout, "dequant") != 0);
+    if (use_exact_small_m) {
+        // Convert [prefix...,group,K] to the grouped [group,M,K] layout used
+        // by the shared-weight verifier kernel.
+        auto grouped_source = mlx::core::reshape(
+            source,
+            Shape{
+                static_cast<int>(rows),
+                group_count,
+                input_size_,
+            });
+        grouped_source = mlx::core::contiguous(
+            mlx::core::transpose(
+                std::move(grouped_source),
+                {1, 0, 2}));
+        const auto grid_y = static_cast<std::size_t>(group_count)
+            * static_cast<std::size_t>(output_per_group / 4);
+        if (grid_y > static_cast<std::size_t>(
+                std::numeric_limits<int>::max())) {
+            throw std::runtime_error(
+                "MXFP8 grouped small-M grid exceeds MLX limits");
+        }
+        auto grouped_output = mxfp8_grouped_small_m_kernel()(
+            {values_, *expanded_mxfp8_scales_, std::move(grouped_source)},
+            {Shape{
+                group_count,
+                static_cast<int>(rows),
+                output_per_group,
+            }},
+            {mlx::core::float16},
+            {32, static_cast<int>(grid_y), 1},
+            {32, 2, 1},
+            {
+                {"M", static_cast<int>(rows)},
+                {"K", input_size_},
+                {"N", output_per_group},
+            },
+            std::nullopt,
+            false,
+            {}).front();
+        auto row_major = mlx::core::transpose(
+            std::move(grouped_output),
+            {1, 0, 2});
+        Shape output_shape(
+            input.shape().begin(),
+            input.shape().end() - 2);
+        output_shape.push_back(group_count);
+        output_shape.push_back(output_per_group);
+        return mlx::core::reshape(
+            std::move(row_major),
+            std::move(output_shape));
+    }
     auto dense = dequantize(source.dtype());
     std::vector<array> pieces;
     pieces.reserve(static_cast<std::size_t>(group_count));
@@ -953,7 +1259,6 @@ array MlxMxWeight::grouped_row_matmul_inverse_rope(
         input_size_ % head_dimension != 0 ||
         cosine.shape() != sine.shape() ||
         cosine.ndim() != 2 ||
-        cosine.shape(0) != 1 ||
         cosine.shape(1) != rotary_dimension / 2) {
         throw std::runtime_error(
             "MXFP8 inverse-RoPE grouped-row shape is incompatible");
@@ -972,9 +1277,10 @@ array MlxMxWeight::grouped_row_matmul_inverse_rope(
         }
         rows *= static_cast<std::size_t>(extent);
     }
-    if (rows != 1) {
+    if (rows < 1 || rows > 6 ||
+        cosine.shape(0) != static_cast<int>(rows)) {
         throw std::runtime_error(
-            "MXFP8 fused inverse-RoPE grouped-row is decode-only");
+            "MXFP8 fused inverse-RoPE supports M=1..6");
     }
 
     const int out_per_group = output_size_ / group_count;
@@ -987,7 +1293,7 @@ array MlxMxWeight::grouped_row_matmul_inverse_rope(
     source = mlx::core::contiguous(
         mlx::core::reshape(
             source,
-            Shape{group_count, input_size_}));
+            Shape{static_cast<int>(rows), group_count, input_size_}));
     auto cos_values = cosine.dtype() == mlx::core::float32
         ? cosine
         : mlx::core::astype(cosine, mlx::core::float32);
@@ -995,9 +1301,13 @@ array MlxMxWeight::grouped_row_matmul_inverse_rope(
         ? sine
         : mlx::core::astype(sine, mlx::core::float32);
     cos_values = mlx::core::contiguous(
-        mlx::core::reshape(cos_values, Shape{rotary_dimension / 2}));
+        mlx::core::reshape(
+            cos_values,
+            Shape{static_cast<int>(rows) * rotary_dimension / 2}));
     sin_values = mlx::core::contiguous(
-        mlx::core::reshape(sin_values, Shape{rotary_dimension / 2}));
+        mlx::core::reshape(
+            sin_values,
+            Shape{static_cast<int>(rows) * rotary_dimension / 2}));
 
     const auto grid =
         static_cast<std::size_t>((output_size_ + 15) / 16) * 128;
@@ -1007,12 +1317,13 @@ array MlxMxWeight::grouped_row_matmul_inverse_rope(
     }
     auto outputs = mxfp8_grouped_inverse_rope_kernel()(
         {values_, scales_, source, cos_values, sin_values},
-        {Shape{output_size_}},
+        {Shape{static_cast<int>(rows), output_size_}},
         {mlx::core::float16},
         {static_cast<int>(grid), 1, 1},
         {128, 1, 1},
         {
             {"GROUP_COUNT", group_count},
+            {"M", static_cast<int>(rows)},
             {"OUT_PER_GROUP", out_per_group},
             {"OUT", output_size_},
             {"K", input_size_},

--- a/cpp_runtime/backends/metal/ops/mlx_sparse_attention.cpp
+++ b/cpp_runtime/backends/metal/ops/mlx_sparse_attention.cpp
@@ -473,15 +473,19 @@ array mlx_sparse_selected_mla_attention(
             {"MAX_SEQ", params.keys},
             {"SELECTED", params.selected},
         };
-        const bool decode = params.queries == 1;
-        const int grid = decode
+        // The decode kernel already maps query rows independently and keeps
+        // the same 32-lane dot/softmax/value reduction as M=1. Use it for
+        // DSpark's M=2..6 verifier blocks as well; the former short-prefill
+        // kernel used eight times as many threads and changed reduction order.
+        const bool decode_consistent = params.queries <= 6;
+        const int grid = decode_consistent
             ? checked_grid_product(
                 {params.batch, params.queries, 16, 128},
                 "selected-token sparse MLA decode grid")
             : checked_grid_product(
                 {params.batch, params.queries, kHeads, 256},
                 "selected-token sparse MLA short-query grid");
-        auto outputs = (decode
+        auto outputs = (decode_consistent
             ? sparse_selected_mla_decode_kernel()
             : sparse_selected_mla_short_kernel())(
                 {
@@ -495,7 +499,7 @@ array mlx_sparse_selected_mla_attention(
                 {output_shape},
                 {mlx::core::float32},
                 {grid, 1, 1},
-                {decode ? 128 : 256, 1, 1},
+                {decode_consistent ? 128 : 256, 1, 1},
                 templates,
                 std::nullopt,
                 false,

--- a/cpp_runtime/backends/metal/runtime/mlx_mtp.cpp
+++ b/cpp_runtime/backends/metal/runtime/mlx_mtp.cpp
@@ -165,6 +165,8 @@ namespace mfq::metal {
 namespace {
 
 constexpr double kDepthAcceptanceAlpha = 0.08;
+constexpr double kDepthAcceptancePrior = 0.6;
+constexpr std::uint64_t kDepthAcceptanceBootstrapTrials = 16;
 constexpr double kDepthTimeTauMs = 400.0;
 constexpr double kDepthProbePeriodMs = 1000.0;
 constexpr double kDepthExplorePeriodMs = 5000.0;
@@ -176,7 +178,14 @@ constexpr double kDepthSpikeDamp = 0.25;
 constexpr double kDepthMarginalMs = 7.0;
 constexpr double kDepthHysteresis = 1.03;
 constexpr double kDepthExitMargin = 1.15;
-constexpr int kDepthExitStreak = 16;
+// oMLX can afford a long losing streak because its standard decoder later
+// schedules MTP re-entry probes. The native C++ engine hands the remainder of
+// this request to plain decode with no re-entry path, so lingering for 16
+// cycles consumes most short generations. The full depth warmup has already
+// measured both alternatives; require only three consecutive losing choices.
+constexpr int kDepthExitStreak = 3;
+constexpr int kDepthRealizedWindow = 3;
+constexpr double kDepthRealizedMargin = 1.03;
 
 } // namespace
 
@@ -186,7 +195,9 @@ MlxMtpDepthController::MlxMtpDepthController(
       current_depth_(maximum_depth_),
       acceptance_(
           static_cast<std::size_t>(maximum_depth_),
-          0.6),
+          kDepthAcceptancePrior),
+      acceptance_hits_(static_cast<std::size_t>(maximum_depth_)),
+      acceptance_trials_(static_cast<std::size_t>(maximum_depth_)),
       cycle_ms_(
           static_cast<std::size_t>(maximum_depth_ + 1)),
       cycle_age_ms_(
@@ -209,9 +220,25 @@ void MlxMtpDepthController::observe(
     accepted_drafts = std::clamp(accepted_drafts, 0, used_depth);
     for (int position = 0; position < used_depth; ++position) {
         const double hit = position < accepted_drafts ? 1.0 : 0.0;
-        auto& estimate = acceptance_[static_cast<std::size_t>(position)];
-        estimate = (1.0 - kDepthAcceptanceAlpha) * estimate +
-            kDepthAcceptanceAlpha * hit;
+        const auto index = static_cast<std::size_t>(position);
+        auto& estimate = acceptance_[index];
+        auto& trials = acceptance_trials_.at(index);
+        auto& hits = acceptance_hits_.at(index);
+        ++trials;
+        hits += static_cast<std::uint64_t>(hit);
+        if (trials <= kDepthAcceptanceBootstrapTrials) {
+            // A controller is created for each request. Bootstrap from the
+            // observed conditional rate with one prior sample, then switch to
+            // oMLX's slow EMA once the estimate is established. Applying the
+            // EMA immediately lets one lucky warmup sweep lock a short,
+            // low-acceptance request at an expensive deep width.
+            estimate = (kDepthAcceptancePrior +
+                        static_cast<double>(hits)) /
+                (1.0 + static_cast<double>(trials));
+        } else {
+            estimate = (1.0 - kDepthAcceptanceAlpha) * estimate +
+                kDepthAcceptanceAlpha * hit;
+        }
         if (position >= accepted_drafts) {
             break;
         }
@@ -220,6 +247,12 @@ void MlxMtpDepthController::observe(
     cycle_ms = std::max(0.0, cycle_ms);
     if (time_sample) {
         update_time(used_depth, cycle_ms);
+        if (used_depth > 0) {
+            ++realized_window_cycles_;
+            realized_window_tokens_ +=
+                static_cast<std::uint64_t>(accepted_drafts + 1);
+            realized_window_ms_ += cycle_ms;
+        }
     }
     for (std::size_t depth = 0; depth < cycle_age_ms_.size(); ++depth) {
         if (cycle_age_ms_[depth]) {
@@ -231,6 +264,24 @@ void MlxMtpDepthController::observe(
     }
     milliseconds_since_probe_ += cycle_ms;
     milliseconds_since_explore_ += cycle_ms;
+
+    const auto resolve_realized_window = [&] {
+        if (realized_window_cycles_ < kDepthRealizedWindow ||
+            !cycle_ms_.front() || realized_window_ms_ <= 0.0) {
+            return;
+        }
+        const double measured_tokens_per_ms =
+            static_cast<double>(realized_window_tokens_) /
+            realized_window_ms_;
+        const double baseline_tokens_per_ms =
+            1.0 / std::max(1.0e-6, *cycle_ms_.front());
+        realized_speculation_losing_ =
+            measured_tokens_per_ms <
+                baseline_tokens_per_ms * kDepthRealizedMargin;
+        realized_window_cycles_ = 0;
+        realized_window_tokens_ = 0;
+        realized_window_ms_ = 0.0;
+    };
 
     if (speculation_losing()) {
         ++exit_streak_;
@@ -244,10 +295,16 @@ void MlxMtpDepthController::observe(
             current_depth_ = warmup_.front();
             return;
         }
+        // The descending sweep plus three plain cycles has measured actual
+        // request-local throughput. A clear loss should hand off immediately
+        // instead of spending the rest of a short response exploring depths.
+        resolve_realized_window();
         current_depth_ = best_depth();
         milliseconds_since_probe_ = 0.0;
         return;
     }
+
+    resolve_realized_window();
 
     if (probe_left_ > 0) {
         --probe_left_;
@@ -284,7 +341,8 @@ void MlxMtpDepthController::observe(
 }
 
 bool MlxMtpDepthController::should_exit() const noexcept {
-    return exit_streak_ >= kDepthExitStreak;
+    return realized_speculation_losing_ ||
+        exit_streak_ >= kDepthExitStreak;
 }
 
 double MlxMtpDepthController::conditional_acceptance(

--- a/cpp_runtime/backends/metal/runtime/mlx_mtp.h
+++ b/cpp_runtime/backends/metal/runtime/mlx_mtp.h
@@ -159,9 +159,15 @@ private:
     int cycles_ = 0;
     int probe_left_ = 0;
     int exit_streak_ = 0;
+    int realized_window_cycles_ = 0;
+    std::uint64_t realized_window_tokens_ = 0;
+    double realized_window_ms_ = 0.0;
+    bool realized_speculation_losing_ = false;
     double milliseconds_since_probe_ = 0.0;
     double milliseconds_since_explore_ = 0.0;
     std::vector<double> acceptance_;
+    std::vector<std::uint64_t> acceptance_hits_;
+    std::vector<std::uint64_t> acceptance_trials_;
     std::vector<std::optional<double>> cycle_ms_;
     std::vector<std::optional<double>> cycle_age_ms_;
     std::vector<int> warmup_;

--- a/cpp_runtime/backends/metal/runtime/mlx_server_components.cpp
+++ b/cpp_runtime/backends/metal/runtime/mlx_server_components.cpp
@@ -608,12 +608,15 @@ MlxServerComponentCallbacks make_mlx_server_components(
                     std::move(permutation),
                 });
             }
-            std::function<void(std::size_t, double)> report_prefill;
+            MlxDeepseekV4PrefillCallback report_prefill;
             if (on_prefill) {
                 report_prefill = [on_prefill](
-                    std::size_t tokens, double model_ms) {
+                    std::size_t tokens,
+                    double llm_ms,
+                    double multimodal_ms,
+                    double model_ms) {
                     on_prefill(MfqPrefillTiming{
-                        tokens, model_ms, 0.0, model_ms});
+                        tokens, llm_ms, multimodal_ms, model_ms});
                 };
             }
             return runtime_holder->value().generate_multimodal(

--- a/cpp_runtime/backends/metal/runtime/mlx_tensor.cpp
+++ b/cpp_runtime/backends/metal/runtime/mlx_tensor.cpp
@@ -4,6 +4,7 @@
 #include <mlx/allocator.h>
 
 #include <atomic>
+#include <cstdlib>
 #include <cstdint>
 #include <cstring>
 #include <limits>
@@ -82,6 +83,79 @@ constexpr const char* kDenseSmallM = R"METAL(
     }
 )METAL";
 
+// M=2..6 verifier GEMV with the same 32-lane reduction geometry as MLX's
+// one-token large-output GEMV. Four output rows share every activation load
+// inside each SIMD group, while each weight is reused across all M inputs.
+//
+// Scheduling derived from oMLX 0.6.4 verify_qmv.py.
+// Copyright © 2026 Apple Inc.  Licensed under Apache-2.0.
+constexpr const char* kDenseSmallMExact = R"METAL(
+    constexpr uint OUTPUTS_PER_SIMD = 4u;
+    constexpr uint SIMD_GROUPS = 8u;
+    constexpr uint OUTPUTS_PER_TG = OUTPUTS_PER_SIMD * SIMD_GROUPS;
+    constexpr uint VALUES_PER_LANE = 4u;
+    constexpr uint K_BLOCK = VALUES_PER_LANE * 32u;
+
+    uint simd_group = simdgroup_index_in_threadgroup;
+    uint lane = thread_index_in_simdgroup;
+    uint output_base =
+        threadgroup_position_in_grid.x * OUTPUTS_PER_TG
+        + simd_group * OUTPUTS_PER_SIMD;
+    if (output_base >= uint(OUT)) {
+        return;
+    }
+
+    uint k_base = lane * VALUES_PER_LANE;
+    float accum[M][OUTPUTS_PER_SIMD] = {{0.0f}};
+    for (uint block = 0u; block < uint(K); block += K_BLOCK) {
+        float input_values[M][VALUES_PER_LANE];
+        for (uint row = 0u; row < uint(M); ++row) {
+            for (uint column = 0u;
+                 column < VALUES_PER_LANE;
+                 ++column) {
+                input_values[row][column] =
+                    float(x[row * uint(K) + k_base + column]);
+            }
+        }
+        for (uint result = 0u;
+             result < OUTPUTS_PER_SIMD;
+             ++result) {
+            device const T* row_weight =
+                weight + (output_base + result) * uint(K) + k_base;
+            float weight_values[VALUES_PER_LANE];
+            for (uint column = 0u;
+                 column < VALUES_PER_LANE;
+                 ++column) {
+                weight_values[column] = float(row_weight[column]);
+            }
+            for (uint row = 0u; row < uint(M); ++row) {
+                for (uint column = 0u;
+                     column < VALUES_PER_LANE;
+                     ++column) {
+                    accum[row][result] +=
+                        weight_values[column] * input_values[row][column];
+                }
+            }
+        }
+        k_base += K_BLOCK;
+    }
+
+    for (uint row = 0u; row < uint(M); ++row) {
+        for (uint result = 0u;
+             result < OUTPUTS_PER_SIMD;
+             ++result) {
+            for (ushort step = 16u; step >= 1u; step >>= 1u) {
+                accum[row][result] +=
+                    simd_shuffle_down(accum[row][result], step);
+            }
+            if (lane == 0u) {
+                y[row * uint(OUT) + output_base + result] =
+                    T(accum[row][result]);
+            }
+        }
+    }
+)METAL";
+
 const mlx::core::fast::CustomKernelFunction& dense_small_m_kernel() {
     static const auto kernel = [] {
         CompileOptions options;
@@ -99,12 +173,68 @@ const mlx::core::fast::CustomKernelFunction& dense_small_m_kernel() {
     return kernel;
 }
 
+const mlx::core::fast::CustomKernelFunction&
+dense_small_m_exact_kernel() {
+    static const auto kernel = [] {
+        CompileOptions options;
+        options.math_mode = MathMode::Fast;
+        return mlx::core::fast::metal_kernel(
+            "mfq_dense_small_m_exact_m2_6",
+            {"weight", "x"},
+            {"y"},
+            kDenseSmallMExact,
+            "",
+            true,
+            false,
+            options);
+    }();
+    return kernel;
+}
+
 array dense_small_m_matmul(
     const array& weight,
     const array& input,
     int rows,
     int input_size,
     int output_size) {
+    const auto* layout = std::getenv(
+        "MFQ_METAL_DENSE_SMALL_M_LAYOUT");
+    const bool exact =
+        input_size % 128 == 0 &&
+        output_size >= 4096 &&
+        output_size % 32 == 0 &&
+        (layout == nullptr || std::strcmp(layout, "legacy") != 0);
+    if (exact) {
+        auto source = mlx::core::reshape(
+            input.flags().row_contiguous
+                ? input
+                : mlx::core::contiguous(input),
+            Shape{rows, input_size});
+        auto outputs = dense_small_m_exact_kernel()(
+            {weight, std::move(source)},
+            {Shape{rows, output_size}},
+            {weight.dtype()},
+            {
+                ((output_size + 31) / 32) * 256,
+                1,
+                1,
+            },
+            {256, 1, 1},
+            {
+                {"T", weight.dtype()},
+                {"M", rows},
+                {"K", input_size},
+                {"OUT", output_size},
+            },
+            std::nullopt,
+            false,
+            {});
+        Shape output_shape = input.shape();
+        output_shape.back() = output_size;
+        return mlx::core::reshape(
+            std::move(outputs.front()),
+            std::move(output_shape));
+    }
     constexpr int simd_groups = 4;
     const int k_lanes = input_size >= 16384 ? 16 : 32;
     const int outputs_per_threadgroup = simd_groups * 32 / k_lanes;
@@ -137,6 +267,32 @@ array dense_small_m_matmul(
     output_shape.back() = output_size;
     return mlx::core::reshape(
         std::move(outputs.front()),
+        std::move(output_shape));
+}
+
+array dense_decode_consistent_matmul(
+    const array& weight,
+    const array& input,
+    int rows,
+    int input_size,
+    int output_size) {
+    // This is the same fallback used by oMLX's decode-consistency patch:
+    // express M independent projections as a batch of matrix-vector
+    // products. MLX consequently keeps its M=1 GEMV reduction for every row
+    // instead of selecting a width-M GEMM kernel.
+    auto source = mlx::core::reshape(
+        input.flags().row_contiguous
+            ? input
+            : mlx::core::contiguous(input),
+        Shape{rows, input_size});
+    auto projected = mlx::core::matmul(
+        weight,
+        mlx::core::expand_dims(std::move(source), -1));
+    projected = mlx::core::squeeze(std::move(projected), -1);
+    Shape output_shape = input.shape();
+    output_shape.back() = output_size;
+    return mlx::core::reshape(
+        std::move(projected),
         std::move(output_shape));
 }
 
@@ -478,15 +634,29 @@ array MlxLinear::operator()(const array& input) const {
     if (rows >= 2 && rows <= 6 &&
         input_size_ % 4 == 0 &&
         dense.size() >= 65536 &&
-        dense.flags().row_contiguous &&
-        (dense.dtype() == mlx::core::float16 ||
-         dense.dtype() == mlx::core::bfloat16)) {
-        return dense_small_m_matmul(
-            dense,
-            source,
-            static_cast<int>(rows),
-            input_size_,
-            output_size_);
+        dense.flags().row_contiguous) {
+        const auto* layout = std::getenv(
+            "MFQ_METAL_DENSE_SMALL_M_LAYOUT");
+        const bool legacy = layout != nullptr &&
+            std::strcmp(layout, "legacy") == 0;
+        if (!legacy &&
+            output_size_ < 4096) {
+            return dense_decode_consistent_matmul(
+                dense,
+                source,
+                static_cast<int>(rows),
+                input_size_,
+                output_size_);
+        }
+        if (dense.dtype() == mlx::core::float16 ||
+            dense.dtype() == mlx::core::bfloat16) {
+            return dense_small_m_matmul(
+                dense,
+                source,
+                static_cast<int>(rows),
+                input_size_,
+                output_size_);
+        }
     }
     return mlx::core::matmul(source, mlx::core::transpose(dense));
 }

--- a/cpp_runtime/backends/metal/tests/mlx_deepseek_v4_causal_lm_test.cpp
+++ b/cpp_runtime/backends/metal/tests/mlx_deepseek_v4_causal_lm_test.cpp
@@ -1448,6 +1448,7 @@ void test_dspark_generation_uses_common_mtp_engine() {
     require(model.supports_mtp(), "DeepSeek-V4 DSpark was not attached");
     mfq::metal::MlxSamplingParams sampling;
     sampling.temperature = 0.0;
+    sampling.mtp_max_draft_tokens = 1;
     std::vector<std::int64_t> emitted;
     const auto count = model.generate(
         {1, 2},

--- a/cpp_runtime/backends/metal/tests/mlx_deepseek_v4_sparse_test.cpp
+++ b/cpp_runtime/backends/metal/tests/mlx_deepseek_v4_sparse_test.cpp
@@ -1022,24 +1022,60 @@ void test_sparse_attention_path(int queries) {
         sinks[head] =
             -0.5f + static_cast<float>(head) / 64.0f;
     }
+    auto query_array = float_array(
+        query,
+        Shape{1, heads, queries, dimension});
+    auto cache_array = float_array(
+        cache,
+        Shape{1, max_seq, dimension});
+    auto index_array = int_array(
+        indices,
+        Shape{1, queries, selected});
+    auto mask_array = float_array(
+        mask,
+        Shape{1, queries, selected});
+    auto sink_array = float_array(sinks, Shape{heads});
     auto output = mfq::metal::attention_dsv4_sparse(
-        float_array(
-            query,
-            Shape{1, heads, queries, dimension}),
-        float_array(
-            cache,
-            Shape{1, max_seq, dimension}),
-        int_array(
-            indices,
-            Shape{1, queries, selected}),
-        float_array(
-            mask,
-            Shape{1, queries, selected}),
-        float_array(sinks, Shape{heads}));
+        query_array,
+        cache_array,
+        index_array,
+        mask_array,
+        sink_array);
     require(
         output.shape() ==
             Shape{1, queries, heads, dimension},
         "sparse attention output shape mismatch");
+    const auto actual = evaluated_float(output);
+    if (queries >= 2 && queries <= 6) {
+        std::vector<array> serial_rows;
+        serial_rows.reserve(static_cast<std::size_t>(queries));
+        for (int query_index = 0;
+             query_index < queries;
+             ++query_index) {
+            serial_rows.push_back(
+                mfq::metal::attention_dsv4_sparse(
+                    mlx::core::slice(
+                        query_array,
+                        Shape{0, 0, query_index, 0},
+                        Shape{1, heads, query_index + 1, dimension}),
+                    cache_array,
+                    mlx::core::slice(
+                        index_array,
+                        Shape{0, query_index, 0},
+                        Shape{1, query_index + 1, selected}),
+                    mlx::core::slice(
+                        mask_array,
+                        Shape{0, query_index, 0},
+                        Shape{1, query_index + 1, selected}),
+                    sink_array));
+        }
+        require_close(
+            actual,
+            evaluated_float(mlx::core::concatenate(serial_rows, 1)),
+            0.0f,
+            "sparse attention decode consistency M=" +
+                std::to_string(queries));
+    }
     const auto expected = sparse_reference(
         queries,
         query,
@@ -1049,7 +1085,7 @@ void test_sparse_attention_path(int queries) {
         sinks,
         scale);
     require_close(
-        evaluated_float(std::move(output)),
+        actual,
         expected,
         queries >= 32 ? 4e-3f : 7e-4f,
         "sparse attention M=" +
@@ -1135,6 +1171,125 @@ void test_direct_decode_attention_path() {
         evaluated_float(std::move(legacy)),
         1e-6f,
         "direct sparse decode attention");
+
+    auto empty_topk = mlx::core::zeros(
+        Shape{1, 1, 0},
+        mlx::core::int32);
+    auto local_plan = mfq::metal::dsv4_build_decode_plan(
+        empty_topk,
+        int_array({seq_len}, Shape{1}),
+        0,
+        1,
+        window);
+    auto selected_local = mfq::metal::attention_dsv4_sparse(
+        float_array(query, Shape{1, heads, 1, dimension}),
+        local_array,
+        local_plan.first,
+        local_plan.second,
+        sink_array);
+    auto direct_local = mfq::metal::attention_dsv4_sparse_decode(
+        float_array(query, Shape{1, heads, 1, dimension}),
+        local_array,
+        std::nullopt,
+        0,
+        empty_topk,
+        sink_array,
+        seq_len,
+        1,
+        window);
+    require_close(
+        evaluated_float(std::move(direct_local)),
+        evaluated_float(std::move(selected_local)),
+        0.0f,
+        "direct local decode attention");
+}
+
+void test_short_prefill_plan_matches_circular_decode() {
+    constexpr int heads = 64;
+    constexpr int dimension = 512;
+    constexpr int window = 4096;
+    constexpr int history = 13;
+    constexpr int queries = 5;
+    std::vector<float> query(
+        static_cast<std::size_t>(heads) * queries * dimension);
+    for (std::size_t index = 0; index < query.size(); ++index) {
+        query[index] = static_cast<float>(
+            static_cast<int>((index * 17 + 3) % 61) - 30) / 64.0f;
+    }
+    std::vector<float> cache(
+        static_cast<std::size_t>(window) * dimension,
+        0.0f);
+    for (int row = 0; row < history + queries; ++row) {
+        for (int feature = 0; feature < dimension; ++feature) {
+            cache[static_cast<std::size_t>(row) * dimension + feature] =
+                static_cast<float>(
+                    ((row * 19 + feature * 7) % 47) - 23) / 48.0f;
+        }
+    }
+    std::vector<float> sinks(heads);
+    for (int head = 0; head < heads; ++head) {
+        sinks[head] = -0.5f + static_cast<float>(head) / 97.0f;
+    }
+    auto query_array = float_array(
+        query,
+        Shape{1, heads, queries, dimension});
+    auto full_cache = mlx::core::astype(
+        float_array(cache, Shape{1, window, dimension}),
+        mlx::core::float16);
+    auto visible_cache = mlx::core::slice(
+        full_cache,
+        Shape{0, 0, 0},
+        Shape{1, history + queries, dimension});
+    auto empty_topk = mlx::core::zeros(
+        Shape{1, queries, 0},
+        mlx::core::int32);
+    auto plan = mfq::metal::dsv4_build_prefill_plan(
+        empty_topk,
+        history,
+        history,
+        0,
+        1,
+        window);
+    require(
+        plan.first.shape() == Shape{1, queries, 32},
+        "short verifier plan retained the full local window");
+    auto batched = mfq::metal::attention_dsv4_sparse(
+        query_array,
+        visible_cache,
+        plan.first,
+        plan.second,
+        float_array(sinks, Shape{heads}));
+    std::vector<array> serial;
+    serial.reserve(queries);
+    for (int row = 0; row < queries; ++row) {
+        auto serial_topk = mlx::core::zeros(
+            Shape{1, 1, 0},
+            mlx::core::int32);
+        auto serial_plan = mfq::metal::dsv4_build_prefill_plan(
+            serial_topk,
+            history + row,
+            history + row,
+            0,
+            1,
+            window);
+        serial.push_back(mfq::metal::attention_dsv4_sparse(
+            mlx::core::slice(
+                query_array,
+                Shape{0, 0, row, 0},
+                Shape{1, heads, row + 1, dimension}),
+            mlx::core::slice(
+                full_cache,
+                Shape{0, 0, 0},
+                Shape{1, history + row + 1, dimension}),
+            serial_plan.first,
+            serial_plan.second,
+            float_array(sinks, Shape{heads})));
+    }
+    require_close(
+        evaluated_float(std::move(batched)),
+        evaluated_float(mlx::core::concatenate(serial, 1)),
+        0.0f,
+        "short verifier attention decode consistency");
 }
 
 void test_invalid_inputs() {
@@ -1268,8 +1423,13 @@ int main() {
         test_sparse_plans();
         test_sparse_attention_path(1);
         test_sparse_attention_path(2);
+        test_sparse_attention_path(3);
+        test_sparse_attention_path(4);
+        test_sparse_attention_path(5);
+        test_sparse_attention_path(6);
         test_sparse_attention_path(32);
         test_direct_decode_attention_path();
+        test_short_prefill_plan_matches_circular_decode();
         test_invalid_inputs();
         std::cout
             << "MFQ C++ DeepSeek-V4 sparse Metal tests passed\n";

--- a/cpp_runtime/backends/metal/tests/mlx_mtp_test.cpp
+++ b/cpp_runtime/backends/metal/tests/mlx_mtp_test.cpp
@@ -35,21 +35,9 @@ int main() {
             controller.observe(0, 0, 30.0);
             controller.observe(0, 0, 29.0);
             controller.observe(0, 0, 31.0);
-            if (controller.depth() != 0) {
+            if (controller.depth() != 0 || !controller.should_exit()) {
                 throw std::runtime_error(
-                    "adaptive MTP controller did not select plain decode");
-            }
-            for (int cycle = 0; cycle < 15; ++cycle) {
-                controller.observe(0, 0, 30.0);
-            }
-            if (controller.should_exit()) {
-                throw std::runtime_error(
-                    "adaptive MTP controller exited before its streak gate");
-            }
-            controller.observe(0, 0, 30.0);
-            if (!controller.should_exit()) {
-                throw std::runtime_error(
-                    "adaptive MTP controller did not park losing speculation");
+                    "adaptive MTP controller did not hand off a measured loss");
             }
         }
         {

--- a/cpp_runtime/backends/metal/tests/mlx_mx_test.cpp
+++ b/cpp_runtime/backends/metal/tests/mlx_mx_test.cpp
@@ -61,6 +61,32 @@ std::vector<std::uint8_t> make_block_scaled_mxfp8_blob() {
     return blob;
 }
 
+std::vector<std::uint8_t> make_patterned_mxfp8_blob(
+    int outputs,
+    int inputs,
+    int salt) {
+    auto blob = make_blob(8, outputs, inputs);
+    constexpr std::size_t header_bytes = 4 + 1 + 1 + 2 + 8 * 6;
+    const std::size_t value_bytes =
+        static_cast<std::size_t>(outputs) * inputs;
+    for (std::size_t index = 0; index < value_bytes; ++index) {
+        // Finite positive and negative E4M3 codes with varied mantissas.
+        const auto magnitude = static_cast<std::uint8_t>(
+            1 + (index * 17 + static_cast<std::size_t>(salt)) % 119);
+        blob[header_bytes + index] = static_cast<std::uint8_t>(
+            magnitude | (((index + salt) & 7u) == 0u ? 0x80u : 0u));
+    }
+    const std::size_t scale_offset = header_bytes + value_bytes;
+    const std::size_t scale_bytes =
+        static_cast<std::size_t>((outputs + 127) / 128) *
+        static_cast<std::size_t>(inputs / 128);
+    for (std::size_t index = 0; index < scale_bytes; ++index) {
+        blob[scale_offset + index] = static_cast<std::uint8_t>(
+            123 + (index * 5 + static_cast<std::size_t>(salt)) % 7);
+    }
+    return blob;
+}
+
 std::vector<std::uint8_t> make_q8_blob(int outputs, int inputs) {
     const int groups = inputs / 32;
     std::vector<std::uint8_t> blob{'N', 'I', '8', '0'};
@@ -163,6 +189,52 @@ void test_native_mxfp8_scale_expansion() {
             output.data<float>()[127] == 320.0f &&
             output.data<float>()[128] == 640.0f,
         "native MXFP8 scale expansion value mismatch");
+}
+
+void test_mxfp8_small_m_matches_decode() {
+    using namespace mlx::core;
+    constexpr int inputs = 512;
+    for (const int outputs : {512, 1024, 2048}) {
+      const auto weight = mfq::metal::MlxMxWeight::from_blob(
+          "MXFP8", make_patterned_mxfp8_blob(outputs, inputs, 3));
+      for (const auto dtype : {float16, bfloat16}) {
+        for (int rows = 2; rows <= 6; ++rows) {
+        std::vector<float> values(
+            static_cast<std::size_t>(rows) * inputs);
+        for (int row = 0; row < rows; ++row) {
+            for (int column = 0; column < inputs; ++column) {
+                values[static_cast<std::size_t>(row) * inputs + column] =
+                    static_cast<float>(((column * 7 + row * 13) % 31) - 15)
+                    / 128.0f;
+            }
+        }
+        auto input = astype(
+            array(values.begin(), Shape{rows, inputs}),
+            dtype);
+        auto actual = contiguous(weight.matmul(input));
+        std::vector<array> reference_rows;
+        reference_rows.reserve(static_cast<std::size_t>(rows));
+        for (int row = 0; row < rows; ++row) {
+            reference_rows.push_back(weight.matmul(slice(
+                input,
+                Shape{row, 0},
+                Shape{row + 1, inputs})));
+        }
+        auto reference = contiguous(concatenate(reference_rows, 0));
+        eval(actual, reference);
+        require(
+            actual.shape() == reference.shape(),
+            "MXFP8 exact small-M shape mismatch");
+        const auto* actual_bits = actual.data<std::uint16_t>();
+        const auto* reference_bits = reference.data<std::uint16_t>();
+        for (std::size_t index = 0; index < actual.size(); ++index) {
+            require(
+                actual_bits[index] == reference_bits[index],
+                "MXFP8 exact small-M differs from serial decode");
+        }
+        }
+      }
+    }
 }
 
 void test_grouped_mxfp8() {
@@ -338,6 +410,62 @@ void test_grouped_mxfp8_swiglu() {
     }
 }
 
+void test_grouped_mxfp8_swiglu_small_m_matches_decode() {
+    using namespace mlx::core;
+    constexpr int inputs = 512;
+    constexpr int outputs = 64;
+    const auto gate = mfq::metal::MlxMxWeight::from_blob(
+        "MXFP8", make_patterned_mxfp8_blob(outputs, inputs, 23));
+    const auto up = mfq::metal::MlxMxWeight::from_blob(
+        "MXFP8", make_patterned_mxfp8_blob(outputs, inputs, 31));
+    const mfq::metal::MlxGroupedLinear grouped({&gate, &up});
+    for (const auto dtype : {float16, bfloat16}) {
+        for (int rows = 2; rows <= 6; ++rows) {
+            std::vector<float> values(
+                static_cast<std::size_t>(rows) * inputs);
+            for (int row = 0; row < rows; ++row) {
+                for (int column = 0; column < inputs; ++column) {
+                    values[static_cast<std::size_t>(row) * inputs + column] =
+                        static_cast<float>(
+                            ((column * 17 + row * 29) % 43) - 21) /
+                        96.0f;
+                }
+            }
+            auto input = astype(
+                array(values.begin(), Shape{1, rows, inputs}),
+                dtype);
+            require(
+                grouped.supports_small_m_swiglu(input),
+                "grouped MXFP8 small-M SwiGLU was not selected");
+            auto actual = contiguous(
+                grouped.small_m_swiglu(input, 1.75f));
+            std::vector<array> serial;
+            serial.reserve(static_cast<std::size_t>(rows));
+            for (int row = 0; row < rows; ++row) {
+                serial.push_back(grouped.single_row_swiglu(
+                    slice(
+                        input,
+                        Shape{0, row, 0},
+                        Shape{1, row + 1, inputs}),
+                    1.75f));
+            }
+            auto reference = contiguous(concatenate(serial, 1));
+            eval(actual, reference);
+            require(
+                actual.shape() == reference.shape(),
+                "grouped MXFP8 small-M SwiGLU shape mismatch");
+            const auto* actual_bytes = actual.data<std::uint8_t>();
+            const auto* reference_bytes = reference.data<std::uint8_t>();
+            require(
+                std::memcmp(
+                    actual_bytes,
+                    reference_bytes,
+                    actual.nbytes()) == 0,
+                "grouped MXFP8 small-M SwiGLU differs from decode");
+        }
+    }
+}
+
 void test_grouped_mxfp8_q8() {
     using namespace mlx::core;
     constexpr int inputs = 128;
@@ -420,6 +548,95 @@ void test_grouped_mxfp8_inverse_rope() {
     }
 }
 
+void test_grouped_mxfp8_inverse_rope_small_m_matches_decode() {
+    using namespace mlx::core;
+    constexpr int groups = 2;
+    constexpr int inputs = 512;
+    constexpr int outputs = 16;
+    constexpr int head_dimension = 128;
+    constexpr int rotary_dimension = 64;
+    const auto weight = mfq::metal::MlxMxWeight::from_blob(
+        "MXFP8", make_patterned_mxfp8_blob(outputs, inputs, 19));
+    for (int rows = 2; rows <= 6; ++rows) {
+        std::vector<float> values(
+            static_cast<std::size_t>(rows) * groups * inputs);
+        for (int row = 0; row < rows; ++row) {
+            for (int group = 0; group < groups; ++group) {
+                for (int column = 0; column < inputs; ++column) {
+                    const auto index =
+                        (static_cast<std::size_t>(row) * groups + group) *
+                            inputs + column;
+                    values[index] = static_cast<float>(
+                        ((column * 13 + group * 17 + row * 23) % 41) - 20)
+                        / 64.0f;
+                }
+            }
+        }
+        std::vector<float> cosine_values(
+            static_cast<std::size_t>(rows) * rotary_dimension / 2);
+        std::vector<float> sine_values(cosine_values.size());
+        for (int row = 0; row < rows; ++row) {
+            for (int pair = 0; pair < rotary_dimension / 2; ++pair) {
+                const float angle =
+                    static_cast<float>((row + 1) * (pair + 1)) / 137.0f;
+                const auto index = static_cast<std::size_t>(row) *
+                    (rotary_dimension / 2) + pair;
+                cosine_values[index] = std::cos(angle);
+                sine_values[index] = std::sin(angle);
+            }
+        }
+        auto input = astype(
+            array(values.begin(), Shape{1, rows, groups, inputs}),
+            float16);
+        const array cosine(
+            cosine_values.begin(),
+            Shape{rows, rotary_dimension / 2});
+        const array sine(
+            sine_values.begin(),
+            Shape{rows, rotary_dimension / 2});
+        auto actual = contiguous(
+            weight.grouped_row_matmul_inverse_rope(
+                input,
+                groups,
+                cosine,
+                sine,
+                head_dimension,
+                rotary_dimension));
+        std::vector<array> serial;
+        serial.reserve(static_cast<std::size_t>(rows));
+        for (int row = 0; row < rows; ++row) {
+            serial.push_back(weight.grouped_row_matmul_inverse_rope(
+                slice(
+                    input,
+                    Shape{0, row, 0, 0},
+                    Shape{1, row + 1, groups, inputs}),
+                groups,
+                slice(
+                    cosine,
+                    Shape{row, 0},
+                    Shape{row + 1, rotary_dimension / 2}),
+                slice(
+                    sine,
+                    Shape{row, 0},
+                    Shape{row + 1, rotary_dimension / 2}),
+                head_dimension,
+                rotary_dimension));
+        }
+        auto reference = contiguous(concatenate(serial, 1));
+        eval(actual, reference);
+        require(
+            actual.shape() == reference.shape(),
+            "MXFP8 inverse-RoPE small-M shape mismatch");
+        const auto* actual_bits = actual.data<std::uint16_t>();
+        const auto* reference_bits = reference.data<std::uint16_t>();
+        for (std::size_t index = 0; index < actual.size(); ++index) {
+            require(
+                actual_bits[index] == reference_bits[index],
+                "MXFP8 inverse-RoPE small-M differs from decode");
+        }
+    }
+}
+
 void test_grouped_row_mxfp8_prefill() {
     using namespace mlx::core;
     constexpr int groups = 2;
@@ -476,6 +693,134 @@ void test_grouped_row_mxfp8_prefill() {
     }
 }
 
+void test_grouped_row_mxfp8_verify() {
+    using namespace mlx::core;
+    constexpr int groups = 2;
+    constexpr int outputs_per_group = 8;
+    constexpr int inputs = 256;
+    const auto weight = mfq::metal::MlxMxWeight::from_blob(
+        "MXFP8",
+        make_blob(
+            8,
+            groups * outputs_per_group,
+            inputs));
+    for (int tokens = 2; tokens <= 6; ++tokens) {
+        std::vector<float> values(
+            static_cast<std::size_t>(tokens) * groups * inputs);
+        for (int token = 0; token < tokens; ++token) {
+            for (int group = 0; group < groups; ++group) {
+                const float value =
+                    static_cast<float>(1 + token * groups + group) /
+                    static_cast<float>(inputs);
+                std::fill_n(
+                    values.begin() +
+                        (static_cast<std::size_t>(token) * groups + group) *
+                            inputs,
+                    inputs,
+                    value);
+            }
+        }
+        auto output = contiguous(astype(
+            weight.grouped_row_matmul(
+                astype(
+                    array(
+                        values.begin(),
+                        Shape{1, tokens, groups, inputs}),
+                    float16),
+                groups),
+            float32));
+        eval(output);
+        require(
+            output.shape() ==
+                Shape{1, tokens, groups, outputs_per_group},
+            "MXFP8 verify grouped-row shape mismatch");
+        for (int token = 0; token < tokens; ++token) {
+            for (int group = 0; group < groups; ++group) {
+                const float expected =
+                    static_cast<float>(1 + token * groups + group);
+                for (int out = 0; out < outputs_per_group; ++out) {
+                    const auto index =
+                        ((static_cast<std::size_t>(token) * groups + group) *
+                            outputs_per_group) + out;
+                    require(
+                        std::fabs(output.data<float>()[index] - expected) <
+                            2e-3f,
+                        "MXFP8 verify grouped-row value mismatch");
+                }
+            }
+        }
+    }
+}
+
+void test_grouped_mxfp8_small_m_matches_decode() {
+    using namespace mlx::core;
+    // Match the released V4F attention input width.  At 512 columns the
+    // final FP16 store can hide reduction-order differences which become
+    // visible after 4096 products.
+    constexpr int inputs = 4096;
+    auto first = mfq::metal::MlxMxWeight::from_blob(
+        "MXFP8", make_patterned_mxfp8_blob(1024, inputs, 3));
+    auto second = mfq::metal::MlxMxWeight::from_blob(
+        "MXFP8", make_patterned_mxfp8_blob(512, inputs, 7));
+    auto third = mfq::metal::MlxMxWeight::from_blob(
+        "MXFP8", make_patterned_mxfp8_blob(64, inputs, 11));
+    const mfq::metal::MlxGroupedLinear grouped({
+        &first,
+        &second,
+        &third,
+    });
+    for (int rows = 2; rows <= 6; ++rows) {
+        std::vector<float> values(
+            static_cast<std::size_t>(rows) * inputs);
+        for (int row = 0; row < rows; ++row) {
+            for (int column = 0; column < inputs; ++column) {
+                values[static_cast<std::size_t>(row) * inputs + column] =
+                    static_cast<float>(((column * 11 + row * 17) % 37) - 18)
+                    / 128.0f;
+            }
+        }
+        auto input = astype(
+            array(values.begin(), Shape{rows, inputs}),
+            float16);
+        auto actual = grouped(input);
+        std::vector<std::vector<array>> serial(3);
+        for (int row = 0; row < rows; ++row) {
+            auto result = grouped(slice(
+                input,
+                Shape{row, 0},
+                Shape{row + 1, inputs}));
+            for (std::size_t projection = 0;
+                 projection < result.size();
+                 ++projection) {
+                serial[projection].push_back(
+                    std::move(result[projection]));
+            }
+        }
+        for (std::size_t projection = 0;
+             projection < actual.size();
+             ++projection) {
+            actual[projection] = contiguous(actual[projection]);
+            auto reference = contiguous(concatenate(
+                serial[projection], 0));
+            eval(actual[projection], reference);
+            require(
+                actual[projection].shape() == reference.shape(),
+                "grouped MXFP8 exact small-M shape mismatch");
+            const auto* actual_bits =
+                actual[projection].data<std::uint16_t>();
+            const auto* reference_bits =
+                reference.data<std::uint16_t>();
+            for (std::size_t index = 0;
+                 index < actual[projection].size();
+                 ++index) {
+                require(
+                    actual_bits[index] == reference_bits[index],
+                    "grouped MXFP8 small-M differs from decode");
+            }
+        }
+    }
+}
+
 } // namespace
 
 int main() {
@@ -494,15 +839,20 @@ int main() {
         test_matmul("MXFP8", 128, 7);
         test_matmul("MXFP8", 128, 64);
         test_native_mxfp8_scale_expansion();
+        test_mxfp8_small_m_matches_decode();
         test_embedding("MXFP4", 96);
         test_embedding("MXFP8", 128);
         test_grouped_mxfp8();
         test_grouped_mx_small_m("MXFP4");
         test_grouped_mx_small_m("MXFP8");
         test_grouped_mxfp8_swiglu();
+        test_grouped_mxfp8_swiglu_small_m_matches_decode();
         test_grouped_mxfp8_q8();
         test_grouped_mxfp8_inverse_rope();
+        test_grouped_mxfp8_inverse_rope_small_m_matches_decode();
         test_grouped_row_mxfp8_prefill();
+        test_grouped_row_mxfp8_verify();
+        test_grouped_mxfp8_small_m_matches_decode();
         std::cout << "MFQ MXFP4/MXFP8 Metal GEMV/MMQ/GEMM/grouped/embedding passed\n";
         return 0;
     } catch (const std::exception& error) {

--- a/cpp_runtime/backends/metal/tests/mlx_tensor_test.cpp
+++ b/cpp_runtime/backends/metal/tests/mlx_tensor_test.cpp
@@ -338,6 +338,59 @@ void test_dense_small_m() {
     }
 }
 
+void test_dense_small_output_m_matches_decode() {
+    using namespace mlx::core;
+    constexpr int width = 4096;
+    constexpr int output = 24;
+    std::vector<float> weight_values(
+        static_cast<std::size_t>(width) * output);
+    for (std::size_t index = 0; index < weight_values.size(); ++index) {
+        weight_values[index] = static_cast<float>(
+            static_cast<int>((index * 29 + 7) % 47) - 23) / 256.0f;
+    }
+    for (const auto dtype : {float16, bfloat16, float32}) {
+        auto weight = astype(
+            array(weight_values.begin(), Shape{output, width}),
+            dtype);
+        const mfq::metal::MlxLinear linear(weight);
+        for (int rows = 2; rows <= 6; ++rows) {
+            std::vector<float> input_values(
+                static_cast<std::size_t>(rows) * width);
+            for (std::size_t index = 0; index < input_values.size(); ++index) {
+                input_values[index] = static_cast<float>(
+                    static_cast<int>((index * 31 + 11) % 53) - 26) /
+                    128.0f;
+            }
+            auto input = astype(
+                array(input_values.begin(), Shape{1, rows, width}),
+                dtype);
+            auto actual = contiguous(linear(input));
+            std::vector<array> serial;
+            serial.reserve(static_cast<std::size_t>(rows));
+            for (int row = 0; row < rows; ++row) {
+                serial.push_back(linear(slice(
+                    input,
+                    Shape{0, row, 0},
+                    Shape{1, row + 1, width})));
+            }
+            auto reference = contiguous(concatenate(serial, 1));
+            eval(actual, reference);
+            require(
+                actual.shape() == reference.shape(),
+                "dense small-output decode shape mismatch");
+            require(
+                actual.nbytes() == reference.nbytes(),
+                "dense small-output decode dtype mismatch");
+            require(
+                std::memcmp(
+                    actual.data<std::uint8_t>(),
+                    reference.data<std::uint8_t>(),
+                    actual.nbytes()) == 0,
+                "dense small-output batch differs from decode");
+        }
+    }
+}
+
 } // namespace
 
 int main() {
@@ -387,6 +440,7 @@ int main() {
         require_close(bf16_values[2], 4.0f);
 
         test_dense_small_m();
+        test_dense_small_output_m_matches_decode();
 
         const array grouped_weight(
             {

--- a/cpp_runtime/core/compat/mfq_legacy_tensor_names.cpp
+++ b/cpp_runtime/core/compat/mfq_legacy_tensor_names.cpp
@@ -681,6 +681,7 @@ void add_deepseek_v4_aliases(
             {"attention.indexer.compressor.norm.weight", "attn.indexer.compressor.norm.weight"},
             {"mlp.router.weight", "ffn.gate.weight"},
             {"mlp.router.bias", "ffn.gate.bias"},
+            {"mlp.router.vision_bias", "ffn.gate.bias_vl"},
             {"mlp.router.token_to_expert", "ffn.gate.tid2eid"},
             {"mlp.experts.gate_up.weight", "ffn.experts.gate_up.weight"},
             {"mlp.experts.gate.weight", "ffn.experts.gate.weight"},

--- a/cpp_runtime/server/src/server.cpp
+++ b/cpp_runtime/server/src/server.cpp
@@ -763,6 +763,7 @@ static MfqRuntimeProfile architecture_runtime_profile(
         result.chat.top_p = 0.8;
         result.chat.repetition_penalty = 1.05;
         result.chat.presence_penalty = 0.0;
+        result.chat.mtp_max_draft_tokens = 4;
         result.source = "architecture-registry:deepseek_v4";
     }
     return result;

--- a/cpp_runtime/tests/mfq_model_graph_test.cpp
+++ b/cpp_runtime/tests/mfq_model_graph_test.cpp
@@ -214,6 +214,9 @@ int main() {
                 "mtp.0.main_proj.weight",
                 "mtp.0.norm.weight",
                 "mtp.0.markov_head.markov_w1.weight",
+                "mtp.2.norm.weight",
+                "layers.0.ffn.gate.bias_vl",
+                "mtp.0.ffn.gate.bias_vl",
             });
         require(
             deepseek_aliases.canonical_to_stored.at(
@@ -230,7 +233,16 @@ int main() {
                 "mtp.0.norm.weight" &&
             deepseek_aliases.canonical_to_stored.at(
                 "predictor.stage.0.markov.input.weight") ==
-                "mtp.0.markov_head.markov_w1.weight",
+                "mtp.0.markov_head.markov_w1.weight" &&
+            deepseek_aliases.canonical_to_stored.at(
+                "predictor.stage.2.output_norm.weight") ==
+                "mtp.2.norm.weight" &&
+            deepseek_aliases.canonical_to_stored.at(
+                "model.block.0.mlp.router.vision_bias") ==
+                "layers.0.ffn.gate.bias_vl" &&
+            deepseek_aliases.canonical_to_stored.at(
+                "predictor.stage.0.mlp.router.vision_bias") ==
+                "mtp.0.ffn.gate.bias_vl",
             "legacy DeepSeek-V4 aliases were not canonicalized");
 
         const auto gemma_aliases = mfq::make_legacy_tensor_aliases(

--- a/mfq/formats/runtime_profile.py
+++ b/mfq/formats/runtime_profile.py
@@ -78,6 +78,7 @@ _ARCHITECTURE_REGISTRY: dict[str, dict[str, Any]] = {
             "top_p": 0.8,
             "repetition_penalty": 1.05,
             "presence_penalty": 0.0,
+            "mtp_max_draft_tokens": 4,
         },
         source="architecture-registry:deepseek_v4",
     ),

--- a/tests/test_runtime_profile.py
+++ b/tests/test_runtime_profile.py
@@ -25,6 +25,10 @@ def test_architecture_registry_is_partial() -> None:
     assert profile["duplex"]["system_prompt"] == "Streaming Omni Conversation."
     assert "max_tokens" not in profile["chat"]
 
+    deepseek = architecture_profile("deepseek_v4_vision")
+    assert deepseek is not None
+    assert deepseek["chat"]["mtp_max_draft_tokens"] == 4
+
 
 def test_exact_model_registry_matches_repository_identity() -> None:
     profile = model_profile("Tylogi/MiniCPM-o-4_5-MFQ")


### PR DESCRIPTION
The released DeepSeek-V4-Flash-Vision HF checkpoint could not use the native Metal path reliably: official tensor names and packed views were incomplete, fully resident expert loading still depended on the SSD cache path, DSpark could overflow during its MXFP8 projection, and partial MTP acceptance replayed attention across all 43 target layers.

This change lets the original 48-shard checkpoint load directly into Apple unified memory, restores correct text and vision inference, and makes MTP profitable when the predictor has sufficient acceptance.

## Changes

- Add official HF aliases for the vision router and DSpark tensors.
- Support fully resident HF expert banks when `--moe-gpu-cache-gb 0`, including parallel shard loading and an Apple UMA wired-memory budget.
- Fix MXFP4/MXFP8 small-M, grouped projection, tensor-view, sparse-attention, and DSpark numerical paths used by target verification.
- Capture verifier KV/compressor projections and commit accepted rows directly instead of replaying attention after partial acceptance.
- Batch speculative checkpoint and cache materialization across layers.
- Adapt the oMLX-style depth controller to request-local C++ execution with fast acceptance bootstrap and a realized tokens/ms handoff to plain decode.
- Report LLM prefill, multimodal prefill, total model prefill, and per-depth MTP metrics separately.

## Measured behavior

Apple M3 Ultra (80-core GPU, 512 GiB unified memory), MLX 0.32.1, original `/DeepSeek-V4-Flash-Vision-Exp` weights:

- Cold load: 81.3 s; 156.30 GiB active after load; 157.60 GiB MLX peak.
- No model-weight file handles or SSD expert reads after loading.
- Plain decode: 23.1-23.5 token/s.
- High-acceptance deterministic continuation: median 23.407 -> 44.151 token/s with MTP (+88.62%, 92.3% acceptance).
- Prose and code prompts: +4.70% and +5.20% at roughly 63-65% acceptance.
- All five text MTP A/B outputs had identical SHA-256 hashes.
- Warm full-prompt prefill: 437-438 token/s at 1,005-2,005 tokens.
- Single-image, ordered two-image, OCR, and chart-value regression prompts all produced correct answers.

Very short low-acceptance completions can still end during the depth-controller warmup. For example, a 28-token two-image answer at 40% acceptance ran at 16.50 token/s versus 21.93 token/s with MTP disabled; callers expecting only a few dozen visual-output tokens should keep `enable_mtp=false`.

## Validation

- Native macOS Metal build completed successfully.
- 13/13 focused C++ tests passed: MX, grouped linear, DeepSeek-V4 attention/causal LM/sparse/MoE/DSpark/vision, MTP, tensor, sparse attention, model graph, and runtime profile.
- `uv run pytest -q tests/test_runtime_profile.py` — 8 passed.
- Real checkpoint regression run: 24 requests, 0 failures.
