### PR TITLE
refactor(studio): consolidate design system and fix UI/UX issues

### DIFF
--- a/MFQStudio/src/App.tsx
+++ b/MFQStudio/src/App.tsx
@@ -823,6 +823,7 @@ type IconName =
   | "activity"
   | "chat"
   | "chart"
+  | "check"
   | "clock"
   | "copy"
   | "flask"
@@ -869,6 +870,7 @@ function Icon({ name, size = 16 }: { name: IconName; size?: number }) {
       {name === "activity" && <><path d="M3 12h4l2.5-7 5 14 2.5-7h4" /></>}
       {name === "chat" && <><path d="M21 15a4 4 0 0 1-4 4H8l-5 3V7a4 4 0 0 1 4-4h10a4 4 0 0 1 4 4z" /></>}
       {name === "chart" && <><path d="M4 19V5M4 19h16" /><path d="m7 15 4-4 3 2 5-6" /></>}
+      {name === "check" && <path d="m5 12.5 4.5 4.5L19 7.5" />}
       {name === "clock" && <><circle cx="12" cy="12" r="9" /><path d="M12 7v5l3.5 2" /></>}
       {name === "copy" && <><rect height="13" rx="2" width="11" x="8" y="8" /><path d="M16 8V5a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h3" /></>}
       {name === "flask" && <><path d="M9 3h6M10 3v6l-5.7 9.2A1.8 1.8 0 0 0 5.8 21h12.4a1.8 1.8 0 0 0 1.5-2.8L14 9V3" /><path d="M7.5 15h9" /></>}
@@ -1565,6 +1567,7 @@ export default function App() {
   const [modelBrowserOpen, setModelBrowserOpen] = useState(false);
   const [modelDirectoryPath, setModelDirectoryPath] = useState("");
   const [studioToken, setStudioToken] = useState("");
+  const [endpointCopied, setEndpointCopied] = useState(false);
   const [editDraft, setEditDraft] = useState<EditDraft | null>(null);
   const [voiceState, setVoiceState] = useState<VoiceState>("idle");
   const [voiceLevel, setVoiceLevel] = useState(0);
@@ -1742,6 +1745,17 @@ export default function App() {
     voiceRef.current?.setPlayback(settings.playbackEnabled);
     document.documentElement.dataset.theme = settings.theme;
   }, [settings]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key === ",") {
+        event.preventDefault();
+        openStudioPage("dashboard", "settings");
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
 
   useEffect(() => {
     localStorage.setItem(STORED_PRESETS_KEY, JSON.stringify(storedPresets));
@@ -2488,6 +2502,8 @@ export default function App() {
   async function copyEndpoint() {
     try {
       await navigator.clipboard.writeText(studio?.service_url || "http://127.0.0.1:8090");
+      setEndpointCopied(true);
+      window.setTimeout(() => setEndpointCopied(false), 1600);
     } catch (cause) {
       setError(errorMessage(cause));
     }
@@ -3998,7 +4014,7 @@ export default function App() {
               </TMPanel> : <EmptyPanel icon="memory" title={tr("推理内存尚未上报", "Runtime memory is unavailable")} message={tr("服务器就绪后会显示模型驻留与缓存状态。", "Memory residency and cache state appear when the server is ready.")} />}
               <div className="overview-footer-grid">
                 <TMPanel className="overview-endpoint-panel">
-                  <div className="overview-panel-title"><Icon name="link" size={15} /><h2>{tr("OpenAI 兼容端点", "OpenAI-compatible endpoint")}</h2><button aria-label={tr("复制端点", "Copy endpoint")} onClick={() => void copyEndpoint()} title={tr("复制端点", "Copy endpoint")} type="button"><Icon name="copy" size={14} /></button></div>
+                  <div className="overview-panel-title"><Icon name="link" size={15} /><h2>{tr("OpenAI 兼容端点", "OpenAI-compatible endpoint")}</h2><button aria-label={endpointCopied ? tr("已复制", "Copied") : tr("复制端点", "Copy endpoint")} className={endpointCopied ? "copied" : ""} onClick={() => void copyEndpoint()} title={endpointCopied ? tr("已复制", "Copied") : tr("复制端点", "Copy endpoint")} type="button"><Icon name={endpointCopied ? "check" : "copy"} size={14} /></button></div>
                   <code>{studio?.service_url || "http://127.0.0.1:8090"}</code>
                   <p>{tr("可直接用于 OpenAI SDK；默认回环地址不经过云端。", "Use this base URL with OpenAI SDKs. The default loopback address sends no traffic to the cloud.")}</p>
                 </TMPanel>

--- a/MFQStudio/src/App.tsx
+++ b/MFQStudio/src/App.tsx
@@ -952,7 +952,11 @@ function ModelMonogram({
   state: ModelMonogramState;
 }) {
   const initial = Array.from(name.trim())[0]?.toLocaleUpperCase() || "E";
-  return <span aria-hidden="true" className={`model-monogram ${state}`}>{initial}</span>;
+  return (
+    <span aria-hidden="true" className={`model-monogram ${state}`}>
+      {state === "idle" ? <img src="/mfq-mark.svg" alt="" /> : initial}
+    </span>
+  );
 }
 
 function MetricTile({
@@ -3852,7 +3856,7 @@ export default function App() {
           <nav className="sectioned-nav" aria-label={tr("推理", "Inference")}>
             <section>
               <div className="sidebar-group-label">{tr("推理", "Inference")}</div>
-              <button className={view === "dashboard" && dashboardPage === "overview" ? "active" : ""} onClick={() => openStudioPage("dashboard", "overview")} type="button"><Icon name="gauge" />{tr("概览", "Overview")}<span>{formatNumber(runtime?.active_requests || 0)}</span></button>
+              <button className={view === "dashboard" && dashboardPage === "overview" ? "active" : ""} onClick={() => openStudioPage("dashboard", "overview")} type="button"><Icon name="gauge" />{tr("概览", "Overview")}{Number(runtime?.active_requests || 0) > 0 && <span>{formatNumber(runtime?.active_requests || 0)}</span>}</button>
               <button className={view === "dashboard" && dashboardPage === "models" ? "active" : ""} onClick={() => openStudioPage("dashboard", "models")} type="button"><Icon name="folder" />{tr("模型", "Models")}</button>
               <button className={view === "dashboard" && dashboardPage === "connections" ? "active" : ""} onClick={openServerPage} type="button"><Icon name="server-rack" />{tr("服务器", "Server")}</button>
               <button className={view === "dashboard" && dashboardPage === "cache" ? "active" : ""} onClick={() => openStudioPage("dashboard", "cache")} type="button"><Icon name="memory" />{tr("资源", "Resources")}</button>

--- a/MFQStudio/src/styles.css
+++ b/MFQStudio/src/styles.css
@@ -517,12 +517,17 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
   width: 54px;
   height: 54px;
   place-items: center;
+  overflow: hidden;
+  border: 1px solid var(--panel-line);
+  border-radius: 14px;
+  background: var(--panel-control);
   color: var(--ink-strong);
-  font-size: 28px;
+  font-size: 26px;
   font-weight: 650;
   letter-spacing: -0.03em;
   line-height: 1;
 }
+.model-monogram img { width: 32px; height: 32px; }
 .model-monogram.loading { color: var(--warning); }
 .model-monogram.ready { color: var(--success); }
 .model-monogram.failed { color: var(--danger); }
@@ -904,7 +909,7 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
 .settings-page { display: grid; }
 .settings-page > .section-label:first-child { margin-top: 2px; }
 .settings-page-inherited { min-width: 0; border: 0; margin: 0; padding: 0; }
-.settings-page-inherited:disabled { opacity: 0.52; }
+.settings-page-inherited:disabled { opacity: 0.65; }
 .settings-page-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; }
 .settings-page-section { display: grid; min-width: 0; align-content: start; }
 .settings-page-panel { min-width: 0; }

--- a/MFQStudio/src/styles.css
+++ b/MFQStudio/src/styles.css
@@ -213,7 +213,7 @@ select:focus-visible, summary:focus-visible {
 .brand img { width: 36px; height: 36px; border-radius: 10px; }
 .brand div { display: grid; gap: 0; }
 .brand strong { color: var(--ink-strong); font-size: 16px; font-weight: 680; letter-spacing: -0.015em; }
-.brand span { color: var(--muted); font-size: 10px; font-weight: 560; letter-spacing: 0.035em; }
+.brand span { color: var(--muted); font-size: 11px; font-weight: 560; letter-spacing: 0.035em; }
 
 .sidebar-scroll {
   display: flex;
@@ -230,7 +230,7 @@ select:focus-visible, summary:focus-visible {
 .sectioned-nav .sidebar-group-label {
   padding: 2px 9px 4px;
   color: var(--muted);
-  font-size: 9px;
+  font-size: 10.5px;
   font-weight: 700;
   letter-spacing: 0.065em;
   text-transform: uppercase;
@@ -260,7 +260,7 @@ select:focus-visible, summary:focus-visible {
   padding: 1px 6px;
   color: inherit;
   background: rgb(127 127 127 / 17%);
-  font-size: 8px;
+  font-size: 9.5px;
   text-align: center;
 }
 
@@ -287,7 +287,7 @@ select:focus-visible, summary:focus-visible {
   white-space: nowrap;
 }
 .sidebar-runtime-card strong { font-size: 11px; font-weight: 620; }
-.sidebar-runtime-card small { color: var(--muted); font-size: 9px; }
+.sidebar-runtime-card small { color: var(--muted); font-size: 10.5px; }
 .runtime-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--muted-light); }
 .runtime-dot.ready { background: var(--success); box-shadow: 0 0 0 4px var(--success-soft); }
 .runtime-dot.busy { background: var(--accent); box-shadow: 0 0 0 4px var(--accent-soft); }
@@ -354,7 +354,7 @@ select:focus-visible, summary:focus-visible {
   padding: 6px 11px;
   color: var(--ink-soft);
   background: var(--surface);
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 610;
 }
 .screen-header-trailing button:hover { border-color: var(--line-strong); color: var(--ink); background: var(--surface-hover); }
@@ -368,12 +368,12 @@ select:focus-visible, summary:focus-visible {
 }
 .section-label strong {
   color: var(--muted);
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 740;
   letter-spacing: 0.075em;
   text-transform: uppercase;
 }
-.section-label span { color: var(--muted-light); font-size: 10px; line-height: 1.45; }
+.section-label span { color: var(--muted-light); font-size: 11px; line-height: 1.45; }
 
 .tm-panel {
   min-width: 0;
@@ -388,7 +388,7 @@ select:focus-visible, summary:focus-visible {
 
 .panel-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 14px; }
 .panel-heading h2 { margin: 0 0 3px; font-size: 15px; font-weight: 640; }
-.panel-heading p { margin: 0; color: var(--muted); font-size: 10px; line-height: 1.45; }
+.panel-heading p { margin: 0; color: var(--muted); font-size: 11px; line-height: 1.45; }
 .panel-heading b { color: var(--ink-soft); font-size: 11px; font-weight: 620; }
 .panel-heading-actions { display: flex; align-items: center; gap: 8px; }
 .panel-heading-actions button {
@@ -398,7 +398,7 @@ select:focus-visible, summary:focus-visible {
   padding: 6px 10px;
   color: var(--ink-soft);
   background: var(--surface);
-  font-size: 10px;
+  font-size: 11px;
 }
 .panel-heading-actions button:hover { border-color: var(--line-strong); color: var(--ink); background: var(--surface-hover); }
 
@@ -426,7 +426,7 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
 .metric-tile-label .ui-icon { color: var(--accent); }
 .metric-tile-label span {
   color: inherit;
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.055em;
   text-transform: uppercase;
@@ -470,14 +470,14 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
 .setting-row:last-child { padding-bottom: 0; }
 .setting-row > div:first-child { display: grid; min-width: 0; gap: 4px; }
 .setting-row > div:first-child > strong { color: var(--ink-soft); font-size: 11px; font-weight: 620; }
-.setting-row > div:first-child > small { color: var(--muted); font-size: 9px; line-height: 1.45; }
+.setting-row > div:first-child > small { color: var(--muted); font-size: 10.5px; line-height: 1.45; }
 .setting-row-trailing { display: flex; min-width: 0; flex: 0 0 auto; align-items: center; justify-content: flex-end; }
 .setting-row-trailing > strong { color: var(--ink-soft); font-size: 11px; font-weight: 620; }
 .setting-row-trailing code {
   overflow: hidden;
   max-width: min(38vw, 420px);
   color: var(--muted);
-  font: 9px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+  font: 10.5px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -488,14 +488,14 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
   padding: 5px 8px;
   color: var(--ink-soft);
   background: var(--panel-control);
-  font-size: 9px;
+  font-size: 10.5px;
 }
 
 .usage-bar { display: grid; gap: 8px; }
 .usage-bar + .usage-bar { margin-top: 18px; }
 .usage-bar > div:first-child { display: flex; align-items: center; justify-content: space-between; gap: 14px; }
 .usage-bar strong { color: var(--ink-soft); font-size: 11px; font-weight: 610; line-height: 1.4; }
-.usage-bar span { color: var(--muted); font: 10px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; }
+.usage-bar span { color: var(--muted); font: 11px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; }
 .usage-bar-track { height: 7px; overflow: hidden; border-radius: 999px; background: rgb(127 127 127 / 10%); }
 .usage-bar-track i { display: block; height: 100%; border-radius: inherit; background: var(--accent); }
 
@@ -509,8 +509,8 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
   text-align: center;
 }
 .empty-panel > strong { color: var(--ink-soft); font-size: 13px; }
-.empty-panel > p { max-width: 480px; margin: 0; color: var(--muted); font-size: 10px; line-height: 1.5; }
-.inline-empty { padding: 24px 0 8px; color: var(--muted); font-size: 10px; text-align: center; }
+.empty-panel > p { max-width: 480px; margin: 0; color: var(--muted); font-size: 11px; line-height: 1.5; }
+.inline-empty { padding: 24px 0 8px; color: var(--muted); font-size: 11px; text-align: center; }
 
 .model-monogram {
   display: grid;
@@ -535,7 +535,7 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
   padding: 6px 9px;
   color: var(--muted);
   background: var(--surface-subtle);
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 650;
   white-space: nowrap;
 }
@@ -643,10 +643,10 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
 .model-state.failed { background: var(--danger); }
 .model-row div, .request-row div { display: grid; min-width: 0; gap: 2px; }
 .model-row strong, .request-row strong { overflow: hidden; color: var(--ink-soft); font-size: 11px; font-weight: 620; text-overflow: ellipsis; white-space: nowrap; }
-.model-row small, .request-row small, .request-row > span { color: var(--muted-light); font-size: 9px; }
-.model-row em { border-radius: 999px; padding: 2px 6px; color: var(--success); background: var(--success-soft); font-size: 8px; font-style: normal; }
+.model-row small, .request-row small, .request-row > span { color: var(--muted-light); font-size: 10.5px; }
+.model-row em { border-radius: 999px; padding: 2px 6px; color: var(--success); background: var(--success-soft); font-size: 10px; font-style: normal; }
 .model-row em.failed { color: var(--danger); background: var(--danger-soft); }
-.model-row > button { border: 1px solid var(--panel-line); border-radius: 8px; padding: 6px 9px; color: var(--accent-ink); background: var(--panel-control); font-size: 9px; }
+.model-row > button { border: 1px solid var(--panel-line); border-radius: 8px; padding: 6px 9px; color: var(--accent-ink); background: var(--panel-control); font-size: 10.5px; }
 .model-row > button:hover { border-color: var(--accent-border); background: var(--accent-soft); }
 .request-row > b { color: var(--ink-soft); font-size: 11px; font-weight: 620; text-align: right; }
 
@@ -673,7 +673,7 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
   color: var(--muted);
   font: 11px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
 }
-.runtime-hero-copy > small { color: var(--muted-light); font-size: 10px; line-height: 1.5; }
+.runtime-hero-copy > small { color: var(--muted-light); font-size: 11px; line-height: 1.5; }
 .runtime-hero-actions { display: flex; gap: 8px; }
 .runtime-hero-actions button {
   display: inline-flex;
@@ -709,7 +709,7 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
   margin-top: 19px;
   padding-top: 14px;
 }
-.overview-memory-facts span { display: inline-flex; align-items: center; gap: 7px; color: var(--muted); font-size: 10px; line-height: 1.45; }
+.overview-memory-facts span { display: inline-flex; align-items: center; gap: 7px; color: var(--muted); font-size: 11px; line-height: 1.45; }
 .overview-memory-facts .ui-icon { color: var(--muted-light); }
 
 .overview-footer-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; margin-top: 14px; }
@@ -730,7 +730,7 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
   background: transparent;
 }
 .overview-panel-title > button:hover { color: var(--ink); background: var(--surface-hover); }
-.overview-panel-title > span { margin-left: auto; color: var(--muted); font: 10px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; }
+.overview-panel-title > span { margin-left: auto; color: var(--muted); font: 11px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; }
 .overview-endpoint-panel > code {
   overflow: hidden;
   color: var(--ink-soft);
@@ -744,44 +744,44 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
 .overview-session-stats { display: flex; gap: 32px; }
 .overview-session-stats > div { display: grid; gap: 3px; }
 .overview-session-stats strong { color: var(--ink-soft); font: 600 15px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; }
-.overview-session-stats small { color: var(--muted-light); font-size: 10px; line-height: 1.4; }
+.overview-session-stats small { color: var(--muted-light); font-size: 11px; line-height: 1.4; }
 
 /* ---------- Cache and profiles page ---------- */
 
 .cache-usage-bars { margin: 17px 0 20px; }
 .cache-stats { display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px; margin-top: 17px; }
 .cache-stats > div { display: grid; gap: 2px; border-left: 2px solid var(--line-strong); padding-left: 11px; }
-.cache-stats span { color: var(--muted-light); font-size: 10px; }
+.cache-stats span { color: var(--muted-light); font-size: 11px; }
 .cache-stats strong { color: var(--ink-soft); font-size: 14px; font-weight: 620; }
-.cache-stats strong small { margin-left: 5px; color: var(--muted-light); font-size: 9px; font-weight: 500; }
+.cache-stats strong small { margin-left: 5px; color: var(--muted-light); font-size: 10.5px; font-weight: 500; }
 
 .profile-panel { margin-top: 0; }
 .profile-create { display: grid; grid-template-columns: minmax(180px, 1fr) auto; gap: 7px; margin-top: 12px; }
-.profile-create input { min-width: 0; border: 1px solid var(--panel-line); border-radius: 7px; padding: 7px 9px; color: var(--ink-soft); background: var(--panel-control); font-size: 10px; }
-.profile-create button, .profile-row button { border: 1px solid var(--panel-line); border-radius: 7px; padding: 6px 9px; color: var(--ink-soft); background: var(--panel-control); font-size: 9px; }
+.profile-create input { min-width: 0; border: 1px solid var(--panel-line); border-radius: 7px; padding: 7px 9px; color: var(--ink-soft); background: var(--panel-control); font-size: 11px; }
+.profile-create button, .profile-row button { border: 1px solid var(--panel-line); border-radius: 7px; padding: 6px 9px; color: var(--ink-soft); background: var(--panel-control); font-size: 10.5px; }
 .profile-create button:hover, .profile-row button:hover { border-color: var(--line-strong); color: var(--ink); background: var(--surface-hover); }
 .profile-list { display: grid; gap: 2px; margin-top: 10px; }
 .profile-row { display: grid; grid-template-columns: minmax(0, 1fr) auto auto; align-items: center; gap: 7px; border-top: 1px solid var(--panel-line); padding: 8px 0; }
 .profile-row > div { display: grid; min-width: 0; gap: 2px; }
-.profile-row strong { color: var(--ink-soft); font-size: 10px; }
-.profile-row small { overflow: hidden; color: var(--muted); font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
+.profile-row strong { color: var(--ink-soft); font-size: 11px; }
+.profile-row small { overflow: hidden; color: var(--muted); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
 .profile-row.drifted strong { color: var(--warning); }
 
 /* ---------- Logs page ---------- */
 
 .runtime-log-list { display: grid; margin-top: 12px; }
 .runtime-log { display: grid; grid-template-columns: 66px minmax(0, 1fr); gap: 8px; border-top: 1px solid var(--panel-line); padding: 7px 1px; }
-.runtime-log span { color: var(--muted-light); font-size: 8px; }
-.runtime-log p { min-width: 0; overflow-wrap: anywhere; margin: 0; color: var(--ink-soft); font: 8px/1.45 ui-monospace, SFMono-Regular, Menlo, monospace; white-space: pre-wrap; }
+.runtime-log span { color: var(--muted-light); font-size: 10px; }
+.runtime-log p { min-width: 0; overflow-wrap: anywhere; margin: 0; color: var(--ink-soft); font: 10px/1.45 ui-monospace, SFMono-Regular, Menlo, monospace; white-space: pre-wrap; }
 .runtime-log.error p { color: var(--danger); }
 
 .job-list { display: grid; max-height: 500px; margin-top: 10px; overflow-y: auto; }
 .job-list > button { display: grid; grid-template-columns: 8px minmax(0, 1fr) 38px; gap: 9px; align-items: center; border: 0; border-top: 1px solid var(--panel-line); padding: 9px 4px; color: inherit; background: transparent; text-align: left; }
 .job-list > button:hover, .job-list > button.active { background: var(--surface-active); }
 .job-list div { display: grid; min-width: 0; gap: 2px; }
-.job-list strong { overflow: hidden; font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
-.job-list small { color: var(--muted-light); font-size: 8px; }
-.job-list b { color: var(--muted); font-size: 8px; text-align: right; }
+.job-list strong { overflow: hidden; font-size: 10.5px; text-overflow: ellipsis; white-space: nowrap; }
+.job-list small { color: var(--muted-light); font-size: 10px; }
+.job-list b { color: var(--muted); font-size: 10px; text-align: right; }
 .job-status { width: 7px; height: 7px; border-radius: 50%; background: var(--muted-light); }
 .job-status.running { background: var(--warning); box-shadow: 0 0 0 3px var(--warning-soft); }
 .job-status.succeeded { background: var(--success); }
@@ -789,21 +789,21 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
 .job-status.cancelling, .job-status.cancelled { background: var(--muted-light); }
 .job-row { display: grid; grid-template-columns: minmax(0, 1fr) minmax(70px, 110px) 38px; gap: 10px; align-items: center; border-top: 1px solid var(--panel-line); padding: 9px 1px; }
 .job-row div { display: grid; min-width: 0; gap: 2px; }
-.job-row strong { overflow: hidden; color: var(--ink-soft); font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
-.job-row small { color: var(--muted-light); font-size: 8px; }
+.job-row strong { overflow: hidden; color: var(--ink-soft); font-size: 10.5px; text-overflow: ellipsis; white-space: nowrap; }
+.job-row small { color: var(--muted-light); font-size: 10px; }
 .job-row progress { width: 100%; height: 5px; accent-color: var(--accent); }
-.job-row > b { color: var(--muted); font-size: 8px; text-align: right; }
+.job-row > b { color: var(--muted); font-size: 10px; text-align: right; }
 .job-row.completed { grid-template-columns: minmax(0, 1fr) minmax(70px, 110px) 38px 24px; }
 .job-row.completed > button { display: grid; width: 24px; height: 24px; place-content: center; border: 0; border-radius: 6px; padding: 0; color: var(--muted); background: transparent; }
 .job-row.completed > button:hover { color: var(--danger); background: var(--danger-soft); }
 .completed-jobs { border-top: 1px solid var(--panel-line); margin-top: 10px; }
-.completed-jobs > summary { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 9px 1px 5px; color: var(--muted); cursor: pointer; font-size: 9px; list-style: none; }
+.completed-jobs > summary { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 9px 1px 5px; color: var(--muted); cursor: pointer; font-size: 10.5px; list-style: none; }
 .completed-jobs > summary::-webkit-details-marker { display: none; }
 .completed-jobs > summary > span { display: inline-flex; align-items: center; gap: 5px; font-weight: 600; }
 .completed-jobs > summary > span::before { content: "›"; display: inline-block; color: var(--muted-light); transition: transform 140ms ease; }
 .completed-jobs[open] > summary > span::before { transform: rotate(90deg); }
-.completed-jobs > summary b { color: var(--muted-light); font-size: 8px; }
-.completed-jobs > summary button { border: 1px solid var(--panel-line); border-radius: 6px; padding: 4px 7px; color: var(--muted); background: var(--panel-control); font-size: 8px; }
+.completed-jobs > summary b { color: var(--muted-light); font-size: 10px; }
+.completed-jobs > summary button { border: 1px solid var(--panel-line); border-radius: 6px; padding: 4px 7px; color: var(--muted); background: var(--panel-control); font-size: 10px; }
 .completed-jobs > summary button:hover { border-color: var(--line-strong); color: var(--danger); background: var(--danger-soft); }
 .completed-jobs .request-table, .completed-jobs .job-list { margin-top: 3px; }
 
@@ -811,19 +811,19 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
 .job-detail > progress { width: 100%; height: 6px; margin: 15px 0 8px; accent-color: var(--accent); }
 .job-result-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; margin: 8px 0; }
 .job-result-grid > div { display: grid; border-left: 2px solid var(--line-strong); padding-left: 9px; }
-.job-result-grid span { color: var(--muted-light); font-size: 8px; }
+.job-result-grid span { color: var(--muted-light); font-size: 10px; }
 .job-result-grid strong { margin-top: 2px; color: var(--ink-soft); font-size: 11px; }
-.job-detail > pre { max-height: 240px; overflow: auto; border-radius: 7px; padding: 10px; color: var(--ink-soft); background: var(--surface-inset); font: 8px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; }
-.job-error { overflow-wrap: anywhere; border-radius: 7px; margin-top: 10px; padding: 9px; color: var(--danger); background: var(--danger-soft); font-size: 9px; white-space: pre-wrap; }
+.job-detail > pre { max-height: 240px; overflow: auto; border-radius: 7px; padding: 10px; color: var(--ink-soft); background: var(--surface-inset); font: 10px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; }
+.job-error { overflow-wrap: anywhere; border-radius: 7px; margin-top: 10px; padding: 9px; color: var(--danger); background: var(--danger-soft); font-size: 10.5px; white-space: pre-wrap; }
 .job-actions { display: flex; gap: 7px; flex-wrap: wrap; }
-.job-actions .secondary { border: 1px solid var(--panel-line); border-radius: 7px; padding: 6px 9px; color: var(--ink-soft); background: var(--panel-control); font-size: 9px; }
+.job-actions .secondary { border: 1px solid var(--panel-line); border-radius: 7px; padding: 6px 9px; color: var(--ink-soft); background: var(--panel-control); font-size: 10.5px; }
 .job-actions .secondary:hover { border-color: var(--line-strong); color: var(--ink); background: var(--surface-hover); }
 .job-actions .danger { color: var(--danger); }
 .job-log { max-height: 320px; margin-top: 12px; overflow: auto; border: 1px solid var(--panel-line); border-radius: 8px; background: var(--panel-control); }
-.job-log header { position: sticky; top: 0; padding: 7px 9px; color: var(--muted); background: var(--surface-subtle); font-size: 8px; text-transform: uppercase; }
+.job-log header { position: sticky; top: 0; padding: 7px 9px; color: var(--muted); background: var(--surface-subtle); font-size: 10px; text-transform: uppercase; }
 .job-log > div { display: grid; grid-template-columns: 70px minmax(0, 1fr); gap: 8px; border-top: 1px solid var(--line-soft); padding: 6px 9px; }
-.job-log time { color: var(--muted-light); font-size: 8px; }
-.job-log code { overflow-wrap: anywhere; color: var(--ink-soft); font: 8px/1.45 ui-monospace, SFMono-Regular, Menlo, monospace; }
+.job-log time { color: var(--muted-light); font-size: 10px; }
+.job-log code { overflow-wrap: anywhere; color: var(--ink-soft); font: 10px/1.45 ui-monospace, SFMono-Regular, Menlo, monospace; }
 .job-log .error code { color: var(--danger); }
 
 /* ---------- Server page ---------- */
@@ -853,7 +853,7 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
   padding: 6px 9px;
   color: var(--ink-soft);
   background: var(--panel-control);
-  font-size: 10px;
+  font-size: 11px;
 }
 .server-page .setting-row-trailing select:focus,
 .server-page .setting-row-trailing input:not([type="checkbox"]):not([type="range"]):focus,
@@ -870,7 +870,7 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
   padding: 6px 11px;
   color: var(--ink-soft);
   background: var(--panel-control);
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 610;
 }
 .server-row-actions > button:hover { border-color: var(--line-strong); background: var(--surface-hover); }
@@ -878,25 +878,25 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
   overflow: hidden;
   max-width: min(28vw, 300px);
   color: var(--ink-soft);
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 610;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 .server-wide-input { width: min(32vw, 360px); }
 .server-number-input { width: 96px; text-align: right; }
-.server-managed-value { color: var(--muted); font-size: 10px; }
+.server-managed-value { color: var(--muted); font-size: 11px; }
 .server-unit-value,
 .server-input-unit { display: flex; align-items: center; justify-content: flex-end; gap: 7px; }
 .server-unit-value strong { color: var(--ink-soft); font: 610 11px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; }
 .server-unit-value span,
-.server-input-unit span { color: var(--muted); font-size: 10px; }
+.server-input-unit span { color: var(--muted); font-size: 11px; }
 .server-prompt-input { width: min(36vw, 410px); resize: vertical; line-height: 1.45; }
 .server-temperature-control { display: flex; align-items: center; gap: 12px; }
 .server-temperature-control input { width: min(20vw, 190px); accent-color: var(--accent); }
-.server-temperature-control strong { width: 42px; color: var(--ink-soft); font: 610 10px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; text-align: right; }
+.server-temperature-control strong { width: 42px; color: var(--ink-soft); font: 610 11px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; text-align: right; }
 .server-page-footer { display: flex; align-items: center; justify-content: flex-end; gap: 14px; margin-top: 18px; }
-.server-page-footer > span { color: var(--muted-light); font-size: 10px; }
+.server-page-footer > span { color: var(--muted-light); font-size: 11px; }
 .server-page-footer > button.primary { border-color: var(--accent); color: var(--on-accent); background: var(--accent); }
 
 /* ---------- Settings page ---------- */
@@ -918,7 +918,7 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
 .settings-inline-fields label > span,
 .settings-page .saved-presets label > span {
   color: var(--muted);
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 610;
   line-height: 1.45;
 }
@@ -932,7 +932,7 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
   padding: 6px 11px;
   color: var(--ink-soft);
   background: var(--panel-control);
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 610;
 }
 .settings-page button:hover,
@@ -949,7 +949,7 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
   padding: 7px 9px;
   color: var(--ink-soft);
   background: var(--panel-control);
-  font-size: 10px;
+  font-size: 11px;
 }
 .settings-page textarea { resize: vertical; line-height: 1.5; }
 .settings-page textarea:focus,
@@ -957,12 +957,12 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
 .settings-page select:focus { border-color: var(--line-strong); box-shadow: 0 0 0 3px var(--accent-soft); }
 .settings-page .saved-presets { gap: 9px; border-top: 1px solid var(--line-soft); margin-top: 0; padding-top: 15px; }
 .settings-page .saved-presets label { display: grid; gap: 6px; margin: 0; }
-.settings-page .saved-presets > small { color: var(--muted-light); font-size: 10px; line-height: 1.5; }
-.settings-page .preset-status { margin: 0; font-size: 10px; }
+.settings-page .saved-presets > small { color: var(--muted-light); font-size: 11px; line-height: 1.5; }
+.settings-page .preset-status { margin: 0; font-size: 11px; }
 .settings-range { display: grid; gap: 8px; }
 .settings-range + .settings-range { border-top: 1px solid var(--line-soft); padding-top: 14px; }
 .settings-range > span { display: flex; justify-content: space-between; gap: 14px; }
-.settings-range output { color: var(--ink-soft); font: 10px/1.45 ui-monospace, SFMono-Regular, Menlo, monospace; }
+.settings-range output { color: var(--ink-soft); font: 11px/1.45 ui-monospace, SFMono-Regular, Menlo, monospace; }
 .settings-range input { width: 100%; accent-color: var(--accent); }
 .settings-inline-fields { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; border-top: 1px solid var(--line-soft); padding-top: 14px; }
 .settings-inline-fields label { display: grid; gap: 6px; }
@@ -975,58 +975,58 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
 .settings-page-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 18px; }
 
 .segmented { display: grid; grid-template-columns: repeat(3, 1fr); gap: 3px; }
-.segmented button { border: 1px solid transparent; border-radius: 7px; padding: 6px 2px; color: var(--muted); background: transparent; font-size: 9px; }
+.segmented button { border: 1px solid transparent; border-radius: 7px; padding: 6px 2px; color: var(--muted); background: transparent; font-size: 10.5px; }
 .segmented button[aria-pressed="true"] { border-color: var(--accent-border); color: var(--accent-ink); background: var(--accent-soft); }
 
 .saved-presets { display: grid; gap: 7px; border-top: 1px solid var(--line-soft); margin-top: 11px; padding-top: 11px; }
 .saved-presets label { margin: 0; }
-.saved-presets > small { color: var(--muted-light); font-size: 8px; line-height: 1.45; }
+.saved-presets > small { color: var(--muted-light); font-size: 10px; line-height: 1.45; }
 .preset-save-row { display: grid; grid-template-columns: minmax(0, 1fr) auto 30px; gap: 5px; }
 .preset-save-row input { min-width: 0; }
 .preset-save-row button { padding-inline: 10px; white-space: nowrap; }
 .preset-save-row .preset-delete { display: grid; width: 30px; place-items: center; padding: 0; color: var(--danger); }
-.preset-status { margin: 0; color: var(--success); font-size: 8px; }
+.preset-status { margin: 0; color: var(--success); font-size: 10px; }
 .preset-status.error { color: var(--danger); }
 .portable-actions { display: flex; gap: 6px; }
-.portable-actions button, .portable-actions label { display: grid; place-items: center; border: 1px solid var(--line); border-radius: 7px; margin: 0; padding: 6px 10px; color: var(--muted); background: var(--surface-subtle); font-size: 9px; cursor: pointer; }
+.portable-actions button, .portable-actions label { display: grid; place-items: center; border: 1px solid var(--line); border-radius: 7px; margin: 0; padding: 6px 10px; color: var(--muted); background: var(--surface-subtle); font-size: 10.5px; cursor: pointer; }
 .portable-actions input { display: none; }
 
 /* ---------- Lab pages ---------- */
 
 .hub-panel { margin-bottom: 10px; }
 .hub-search { display: grid; grid-template-columns: auto minmax(180px, 1fr) auto; gap: 7px; margin-top: 12px; }
-.hub-search input, .hub-search select, .hub-search button, .hub-detail button { min-width: 0; border: 1px solid var(--panel-line); border-radius: 7px; padding: 7px 9px; color: var(--ink); background: var(--panel-control); font-size: 9px; }
+.hub-search input, .hub-search select, .hub-search button, .hub-detail button { min-width: 0; border: 1px solid var(--panel-line); border-radius: 7px; padding: 7px 9px; color: var(--ink); background: var(--panel-control); font-size: 10.5px; }
 .hub-search button:hover, .hub-detail button:hover { border-color: var(--line-strong); background: var(--surface-hover); }
 .hub-results { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 4px; margin-top: 10px; }
 .hub-results > button { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 8px; border: 1px solid var(--panel-line); border-radius: 7px; padding: 8px; color: inherit; background: var(--panel-control); text-align: left; }
 .hub-results > button.active, .hub-results > button:hover { border-color: var(--accent-border); background: var(--accent-soft); }
 .hub-results div, .hub-detail > div { display: grid; min-width: 0; gap: 2px; }
-.hub-results strong, .hub-detail strong { overflow: hidden; font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
-.hub-results small, .hub-detail small, .hub-results span { color: var(--muted); font-size: 8px; }
+.hub-results strong, .hub-detail strong { overflow: hidden; font-size: 10.5px; text-overflow: ellipsis; white-space: nowrap; }
+.hub-results small, .hub-detail small, .hub-results span { color: var(--muted); font-size: 10px; }
 .hub-detail { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 10px; border-top: 1px solid var(--panel-line); margin-top: 10px; padding-top: 10px; }
 .hub-detail button { display: flex; align-items: center; gap: 5px; }
 
 .node-form { display: grid; grid-template-columns: minmax(100px, .4fr) minmax(180px, 1fr) minmax(160px, .8fr) auto; gap: 7px; margin-top: 12px; }
-.node-form input, .node-form button { min-width: 0; border: 1px solid var(--panel-line); border-radius: 7px; padding: 7px 9px; color: var(--ink-soft); background: var(--panel-control); font-size: 9px; }
+.node-form input, .node-form button { min-width: 0; border: 1px solid var(--panel-line); border-radius: 7px; padding: 7px 9px; color: var(--ink-soft); background: var(--panel-control); font-size: 10.5px; }
 .node-list { display: grid; margin-top: 10px; }
 .node-list > div { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 8px; border-top: 1px solid var(--panel-line); padding: 8px 0; }
 .node-list > div > div { display: grid; min-width: 0; gap: 2px; }
-.node-list strong { color: var(--ink-soft); font-size: 10px; }
-.node-list small { overflow: hidden; color: var(--muted); font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
-.node-list button { border: 0; color: var(--muted); background: transparent; font-size: 9px; }
+.node-list strong { color: var(--ink-soft); font-size: 11px; }
+.node-list small { overflow: hidden; color: var(--muted); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
+.node-list button { border: 0; color: var(--muted); background: transparent; font-size: 10.5px; }
 
 .mcp-panel { margin-top: 10px; }
 .cluster-panel { margin-top: 10px; }
 .mcp-form { display: grid; grid-template-columns: minmax(110px, .3fr) auto minmax(240px, 1fr) auto; gap: 7px; margin-top: 12px; }
-.mcp-form input, .mcp-form select { min-width: 0; border: 1px solid var(--panel-line); border-radius: 7px; padding: 7px 9px; color: var(--ink-soft); background: var(--panel-control); font-size: 10px; }
-.mcp-form button { min-width: 64px; border: 1px solid var(--accent); border-radius: 7px; padding: 7px 11px; color: var(--on-accent); background: var(--accent); font-size: 9px; font-weight: 620; }
+.mcp-form input, .mcp-form select { min-width: 0; border: 1px solid var(--panel-line); border-radius: 7px; padding: 7px 9px; color: var(--ink-soft); background: var(--panel-control); font-size: 11px; }
+.mcp-form button { min-width: 64px; border: 1px solid var(--accent); border-radius: 7px; padding: 7px 11px; color: var(--on-accent); background: var(--accent); font-size: 10.5px; font-weight: 620; }
 .mcp-form button:hover { border-color: var(--accent-hover); background: var(--accent-hover); }
 .mcp-server-list { display: grid; gap: 4px; margin-top: 10px; }
 .mcp-server { display: grid; grid-template-columns: auto minmax(0, 1fr) auto auto; align-items: center; gap: 8px; border-top: 1px solid var(--panel-line); padding: 8px 0; }
 .mcp-server div { display: grid; min-width: 0; gap: 2px; }
-.mcp-server strong { color: var(--ink-soft); font-size: 10px; }
-.mcp-server small { overflow: hidden; color: var(--muted); font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
-.mcp-server button { border: 0; color: var(--muted); background: transparent; font-size: 9px; }
+.mcp-server strong { color: var(--ink-soft); font-size: 11px; }
+.mcp-server small { overflow: hidden; color: var(--muted); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
+.mcp-server button { border: 0; color: var(--muted); background: transparent; font-size: 10.5px; }
 
 .panel-action { width: 100%; border: 1px solid var(--line); border-radius: 9px; margin-top: 7px; padding: 8px 10px; color: var(--muted); background: var(--panel-control); font-size: 11px; }
 .panel-action:hover { border-color: var(--line-strong); color: var(--ink); background: var(--surface-hover); }
@@ -1035,39 +1035,39 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
 .evaluation-list, .dataset-list, .lineage-list { display: grid; gap: 3px; margin-top: 11px; }
 .evaluation-list > label { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 8px; border-top: 1px solid var(--panel-line); padding: 8px 1px; }
 .evaluation-list div, .dataset-list div > div, .lineage-list summary > div { display: grid; min-width: 0; gap: 2px; }
-.evaluation-list strong, .dataset-list strong, .lineage-list strong { overflow: hidden; font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
-.evaluation-list small, .dataset-list small, .lineage-list small, .evaluation-list > label > span { color: var(--muted); font-size: 8px; }
+.evaluation-list strong, .dataset-list strong, .lineage-list strong { overflow: hidden; font-size: 10.5px; text-overflow: ellipsis; white-space: nowrap; }
+.evaluation-list small, .dataset-list small, .lineage-list small, .evaluation-list > label > span { color: var(--muted); font-size: 10px; }
 .comparison-table { margin-top: 10px; overflow-x: auto; }
-.comparison-table header, .comparison-table > div { display: grid; grid-template-columns: minmax(120px, 1fr) repeat(4, minmax(90px, auto)); gap: 8px; border-top: 1px solid var(--panel-line); padding: 7px 1px; font-size: 8px; }
+.comparison-table header, .comparison-table > div { display: grid; grid-template-columns: minmax(120px, 1fr) repeat(4, minmax(90px, auto)); gap: 8px; border-top: 1px solid var(--panel-line); padding: 7px 1px; font-size: 10px; }
 .comparison-table header { color: var(--muted); }
 .comparison-table small { color: var(--accent); }
 .dataset-form { display: grid; grid-template-columns: minmax(90px, .7fr) auto minmax(150px, 1fr) auto; gap: 6px; margin-top: 11px; }
-.dataset-form input, .dataset-form select, .dataset-form button { min-width: 0; border: 1px solid var(--panel-line); border-radius: 7px; padding: 7px 8px; color: var(--ink-soft); background: var(--panel-control); font-size: 9px; }
+.dataset-form input, .dataset-form select, .dataset-form button { min-width: 0; border: 1px solid var(--panel-line); border-radius: 7px; padding: 7px 8px; color: var(--ink-soft); background: var(--panel-control); font-size: 10.5px; }
 .dataset-list > div { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; border-top: 1px solid var(--panel-line); padding: 8px 1px; }
 .dataset-list button { border: 0; color: var(--muted); background: transparent; }
 .lineage-panel { margin-bottom: 10px; }
 .lineage-list details { border-top: 1px solid var(--panel-line); }
 .lineage-list summary { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 8px; padding: 8px 1px; cursor: pointer; }
-.lineage-list summary > span { color: var(--muted); font-size: 8px; }
+.lineage-list summary > span { color: var(--muted); font-size: 10px; }
 .lineage-list dl { margin: 0 10px; }
-.lineage-list pre { max-height: 180px; overflow: auto; border-radius: 7px; padding: 9px; background: var(--surface-subtle); font: 8px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; }
+.lineage-list pre { max-height: 180px; overflow: auto; border-radius: 7px; padding: 9px; background: var(--surface-subtle); font: 10px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; }
 
 .imatrix-panel { margin-bottom: 10px; }
 .imatrix-actions { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 10px; }
-.imatrix-actions button { display: inline-flex; height: 25px; align-items: center; gap: 4px; border: 1px solid var(--panel-line); border-radius: 6px; padding: 0 7px; color: var(--muted); background: var(--panel-control); font-size: 8px; font-weight: 550; line-height: 1; }
+.imatrix-actions button { display: inline-flex; height: 28px; align-items: center; gap: 4px; border: 1px solid var(--panel-line); border-radius: 6px; padding: 0 8px; color: var(--muted); background: var(--panel-control); font-size: 10px; font-weight: 550; line-height: 1; }
 .imatrix-actions button:hover { border-color: var(--line-strong); color: var(--ink); background: var(--surface-hover); }
 .imatrix-list { display: grid; gap: 5px; margin-top: 9px; }
 .imatrix-list button { display: flex; align-items: center; justify-content: space-between; gap: 12px; width: 100%; padding: 8px 9px; border: 1px solid var(--panel-line); border-radius: 7px; background: var(--panel-control); color: var(--ink); text-align: left; }
 .imatrix-list button:hover { border-color: var(--accent-border); }
 .imatrix-list button div { min-width: 0; display: grid; gap: 2px; }
 .imatrix-list strong, .imatrix-list small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.imatrix-list small { color: var(--muted); font-size: 8px; }
-.imatrix-list span { flex: 0 0 auto; color: var(--accent); font-size: 8px; font-weight: 650; }
+.imatrix-list small { color: var(--muted); font-size: 10px; }
+.imatrix-list span { flex: 0 0 auto; color: var(--accent); font-size: 10px; font-weight: 650; }
 
-.job-builder label { display: grid; gap: 5px; margin-top: 10px; color: var(--muted); font-size: 9px; }
+.job-builder label { display: grid; gap: 5px; margin-top: 10px; color: var(--muted); font-size: 10.5px; }
 .job-builder label > span { color: var(--ink-soft); font-weight: 600; }
-.job-builder label > small { color: var(--muted-light); font-size: 8px; line-height: 1.45; }
-.job-builder input:not([type="checkbox"]), .job-builder select { width: 100%; border: 1px solid var(--panel-line); border-radius: 7px; outline: 0; padding: 7px 8px; color: var(--ink); background: var(--panel-control); font-size: 9px; }
+.job-builder label > small { color: var(--muted-light); font-size: 10px; line-height: 1.45; }
+.job-builder input:not([type="checkbox"]), .job-builder select { width: 100%; border: 1px solid var(--panel-line); border-radius: 7px; outline: 0; padding: 7px 8px; color: var(--ink); background: var(--panel-control); font-size: 10.5px; }
 .job-builder input:focus, .job-builder select:focus { border-color: var(--accent-border); box-shadow: 0 0 0 2px var(--accent-soft); }
 .job-submit { display: flex; justify-content: flex-end; border-top: 1px solid var(--panel-line); margin-top: 16px; padding-top: 12px; }
 .job-run {
@@ -1082,7 +1082,7 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
   padding: 0 15px;
   color: var(--on-accent);
   background: var(--accent);
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 650;
   box-shadow: var(--shadow-sm);
 }
@@ -1132,7 +1132,7 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.chat-model-summary small { color: var(--muted); font-size: 8px; white-space: nowrap; }
+.chat-model-summary small { color: var(--muted); font-size: 10px; white-space: nowrap; }
 .chat-icon-button {
   display: grid;
   width: 31px;
@@ -1188,15 +1188,15 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
 .message-user .message-content { border: 0; border-radius: 12px; padding: 15px; background: var(--surface-user); }
 .message-meta { display: flex; align-items: baseline; gap: 8px; margin-bottom: 8px; }
 .message-meta strong { color: var(--ink-soft); font-size: 11px; font-weight: 650; }
-.message-meta span { color: var(--muted-light); font-size: 9px; }
+.message-meta span { color: var(--muted-light); font-size: 10.5px; }
 .message-actions { display: flex; gap: 2px; margin-top: 9px; opacity: 0; transition: opacity 120ms; }
 .message-user .message-actions { justify-content: flex-end; }
 .message:hover .message-actions, .message:focus-within .message-actions { opacity: 1; }
-.message-actions button { border: 0; border-radius: 7px; padding: 4px 7px; color: var(--muted-light); background: transparent; font-size: 10px; }
+.message-actions button { border: 0; border-radius: 7px; padding: 4px 7px; color: var(--muted-light); background: transparent; font-size: 11px; }
 .message-actions button:hover { color: var(--ink); background: var(--accent-soft); }
 .live-message .message-avatar { box-shadow: none; }
 
-.response-metrics { margin-top: 7px; color: var(--muted-light); font-size: 10px; }
+.response-metrics { margin-top: 7px; color: var(--muted-light); font-size: 11px; }
 .response-metrics summary { display: flex; width: fit-content; cursor: pointer; gap: 8px; list-style: none; }
 .response-metrics summary::-webkit-details-marker { display: none; }
 .response-metrics summary span + span { border-left: 1px solid var(--line); padding-left: 8px; }
@@ -1215,7 +1215,7 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
 .rich-text code { border: 1px solid var(--line); border-radius: 5px; padding: 0.1em 0.32em; color: var(--accent-ink); background: var(--surface-subtle); font-family: "SFMono-Regular", "Cascadia Code", Consolas, monospace; font-size: 0.88em; }
 .rich-text pre { position: relative; overflow-x: auto; border: 1px solid var(--line); border-radius: 12px; padding: 30px 14px 14px; color: var(--ink); background: var(--surface-inset); }
 .rich-text pre code { border: 0; padding: 0; color: inherit; background: transparent; }
-.code-copy { position: absolute; top: 6px; right: 7px; border: 1px solid var(--line-strong); border-radius: 6px; padding: 3px 7px; color: var(--muted); background: var(--surface-subtle); font-size: 8px; }
+.code-copy { position: absolute; top: 6px; right: 7px; border: 1px solid var(--line-strong); border-radius: 6px; padding: 3px 7px; color: var(--muted); background: var(--surface-subtle); font-size: 10px; }
 .code-copy:hover { color: var(--ink); background: var(--surface-hover); }
 .rich-text blockquote { border-left: 2px solid var(--accent); margin-left: 0; padding-left: 12px; color: var(--muted); }
 .rich-text a { color: var(--accent-ink); text-underline-offset: 2px; }
@@ -1226,13 +1226,13 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
 .rich-text th { background: var(--surface-subtle); font-weight: 650; }
 
 .reasoning { border: 1px solid var(--line-soft); border-radius: 11px; margin: 3px 0 10px; padding: 8px 10px; color: var(--muted); background: var(--surface-subtle); }
-.reasoning summary { cursor: pointer; color: var(--muted); font-size: 10px; font-weight: 620; }
+.reasoning summary { cursor: pointer; color: var(--muted); font-size: 11px; font-weight: 620; }
 .reasoning .rich-text { margin-top: 8px; color: var(--muted); font-size: 11.5px; }
 
-.tool-call { overflow-x: auto; border: 1px solid var(--line); border-radius: 9px; padding: 10px; color: var(--ink-soft); background: var(--surface-inset); font-size: 10px; }
+.tool-call { overflow-x: auto; border: 1px solid var(--line); border-radius: 9px; padding: 10px; color: var(--ink-soft); background: var(--surface-inset); font-size: 11px; }
 .tool-call pre { margin: 0; color: inherit; white-space: pre-wrap; }
 .tool-confirm { margin-top: 6px; }
-.tool-confirm button { border: 1px solid var(--accent-border); border-radius: 7px; padding: 5px 8px; color: var(--accent-ink); background: var(--accent-soft); font-size: 9px; }
+.tool-confirm button { border: 1px solid var(--accent-border); border-radius: 7px; padding: 5px 8px; color: var(--accent-ink); background: var(--accent-soft); font-size: 10.5px; }
 
 .message-editor { display: grid; gap: 7px; }
 .message-editor textarea { width: 100%; min-height: 90px; resize: vertical; border: 1px solid var(--line); border-radius: 8px; outline: none; padding: 9px; color: var(--ink); background: var(--surface-control); }
@@ -1244,20 +1244,20 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
 .media-image { width: auto; }
 .media-video { width: min(560px, 100%); }
 .message-audio { width: min(420px, 100%); height: 34px; margin-top: 9px; }
-.message-media-status { display: block; width: min(360px, 100%); border: 1px solid var(--line); border-radius: 9px; margin: 4px 0 10px; padding: 10px; color: var(--muted); background: var(--surface-subtle); font-size: 9px; }
+.message-media-status { display: block; width: min(360px, 100%); border: 1px solid var(--line); border-radius: 9px; margin: 4px 0 10px; padding: 10px; color: var(--muted); background: var(--surface-subtle); font-size: 10.5px; }
 .message-document { display: flex; width: min(360px, 100%); align-items: center; gap: 9px; border: 1px solid var(--line); border-radius: 9px; margin: 5px 0; padding: 8px; color: inherit; background: var(--surface); font: inherit; text-align: left; cursor: pointer; }
 .message-document:disabled { cursor: progress; opacity: 0.7; }
-.message-document > span { display: grid; width: 31px; height: 31px; place-items: center; border-radius: 7px; color: var(--accent); background: var(--accent-soft); font-size: 8px; font-weight: 700; }
+.message-document > span { display: grid; width: 31px; height: 31px; place-items: center; border-radius: 7px; color: var(--accent); background: var(--accent-soft); font-size: 10px; font-weight: 700; }
 .message-document div { display: grid; min-width: 0; gap: 2px; }
-.message-document strong { overflow: hidden; color: var(--ink); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
-.message-document small { color: var(--muted-light); font-size: 8px; }
+.message-document strong { overflow: hidden; color: var(--ink); font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
+.message-document small { color: var(--muted-light); font-size: 10px; }
 .thinking { display: flex; gap: 4px; padding: 10px 0; }
 .thinking i { width: 5px; height: 5px; border-radius: 50%; background: var(--accent); animation: bounce 1s infinite ease-in-out; }
 .thinking i:nth-child(2) { animation-delay: 120ms; }
 .thinking i:nth-child(3) { animation-delay: 240ms; }
 @keyframes bounce { 50% { opacity: 0.35; transform: translateY(-3px); } }
 
-.error-banner { display: flex; width: min(812px, calc(100% - 40px)); max-height: 148px; align-items: flex-start; justify-content: space-between; gap: 10px; overflow: auto; border: 1px solid var(--danger); border-radius: 8px; margin: 0 auto 8px; padding: 8px 10px; color: var(--danger); background: var(--danger-soft); font-size: 10px; }
+.error-banner { display: flex; width: min(812px, calc(100% - 40px)); max-height: 148px; align-items: flex-start; justify-content: space-between; gap: 10px; overflow: auto; border: 1px solid var(--danger); border-radius: 8px; margin: 0 auto 8px; padding: 8px 10px; color: var(--danger); background: var(--danger-soft); font-size: 11px; }
 .error-banner span { min-width: 0; overflow-wrap: anywhere; white-space: pre-wrap; }
 .error-banner button { border: 0; color: inherit; background: transparent; }
 
@@ -1272,25 +1272,25 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
 .composer-region > .composer,
 .composer-region > .voice-component-banner,
 .composer-region > p { width: min(850px, 100%); margin-inline: auto; }
-.composer-region > p { margin-block: 6px 0; color: var(--muted-light); font-size: 8px; text-align: center; }
+.composer-region > p { margin-block: 6px 0; color: var(--muted-light); font-size: 10px; text-align: center; }
 .voice-component-banner { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 7px 12px; border: 1px solid var(--accent-border); border-radius: 10px; margin-bottom: 8px; padding: 9px 10px; color: var(--accent-ink); background: var(--accent-soft); }
 .voice-component-banner > div { display: grid; min-width: 0; gap: 2px; }
-.voice-component-banner strong { font-size: 10px; }
-.voice-component-banner span { overflow: hidden; color: var(--muted); font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
+.voice-component-banner strong { font-size: 11px; }
+.voice-component-banner span { overflow: hidden; color: var(--muted); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
 .voice-component-banner progress { width: 100%; height: 4px; grid-column: 1 / -1; accent-color: var(--accent); }
-.voice-component-banner button { grid-column: 2; grid-row: 1; border: 1px solid var(--accent-border); border-radius: 7px; padding: 6px 9px; color: var(--on-accent); background: var(--accent); font-size: 9px; font-weight: 650; }
+.voice-component-banner button { grid-column: 2; grid-row: 1; border: 1px solid var(--accent-border); border-radius: 7px; padding: 6px 9px; color: var(--on-accent); background: var(--accent); font-size: 10.5px; font-weight: 650; }
 .voice-component-banner button:disabled { cursor: progress; opacity: 0.65; }
 .composer { overflow: hidden; border: 1px solid var(--line); border-radius: 12px; background: var(--surface); box-shadow: none; }
 .composer:focus-within { border-color: var(--line-strong); box-shadow: 0 0 0 3px var(--accent-soft); }
 .composer textarea { display: block; width: 100%; min-height: 48px; max-height: 180px; resize: none; border: 0; outline: 0; padding: 12px 13px 5px; color: var(--ink); background: transparent; font-size: 13px; line-height: 1.5; }
 .composer textarea::placeholder { color: var(--muted-light); }
 .composer-toolbar { display: flex; min-height: 42px; align-items: center; gap: 4px; padding: 5px 7px 7px; }
-.composer-toolbar > button, .composer-toolbar select { display: flex; height: 31px; align-items: center; justify-content: center; gap: 5px; border: 1px solid var(--line); border-radius: 8px; padding: 0 7px; color: var(--muted); background: var(--surface-subtle); font-size: 10px; }
+.composer-toolbar > button, .composer-toolbar select { display: flex; height: 31px; align-items: center; justify-content: center; gap: 5px; border: 1px solid var(--line); border-radius: 8px; padding: 0 7px; color: var(--muted); background: var(--surface-subtle); font-size: 11px; }
 .composer-toolbar > button:hover, .composer-toolbar select:hover { border-color: var(--line-strong); color: var(--ink); background: var(--surface-hover); }
 .composer-toolbar > button[aria-pressed="true"] { border-color: var(--accent-border); color: var(--ink); background: var(--accent-soft); }
 .composer-toolbar .voice-button { position: relative; width: 28px; padding: 0; border-radius: 50%; }
 .voice-button span { position: absolute; inset: 8px; border-radius: 50%; background: var(--accent); transform: scale(calc(0.82 + var(--voice-level) * 0.38)); box-shadow: 0 0 calc(4px + var(--voice-level) * 9px) var(--accent-soft); }
-.composer-hint { margin-left: auto; color: var(--muted-light); font-size: 9px; }
+.composer-hint { margin-left: auto; color: var(--muted-light); font-size: 10.5px; }
 .composer-toolbar .send-button { width: 32px; border-color: var(--accent); border-radius: 50%; padding: 0; color: var(--on-accent); background: var(--accent); }
 .composer-toolbar .send-button:hover { border-color: var(--accent-hover); background: var(--accent-hover); }
 .composer-toolbar .send-button.stop { border-color: var(--danger); color: #fff; background: var(--danger); }
@@ -1298,8 +1298,8 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
 .attachment-chip { position: relative; display: grid; min-width: 178px; grid-template-columns: 36px minmax(0, 1fr) 20px; align-items: center; gap: 7px; border: 1px solid var(--line); border-radius: 8px; padding: 5px; background: var(--surface-subtle); }
 .attachment-chip > img, .attachment-chip > video, .attachment-chip > span { display: grid; width: 36px; height: 36px; place-items: center; border-radius: 6px; background: var(--surface-hover); object-fit: cover; }
 .attachment-chip div { display: grid; min-width: 0; }
-.attachment-chip strong { overflow: hidden; font-size: 9px; font-weight: 620; text-overflow: ellipsis; white-space: nowrap; }
-.attachment-chip small { color: var(--muted); font-size: 8px; }
+.attachment-chip strong { overflow: hidden; font-size: 10.5px; font-weight: 620; text-overflow: ellipsis; white-space: nowrap; }
+.attachment-chip small { color: var(--muted); font-size: 10px; }
 .attachment-chip button { border: 0; color: var(--muted); background: transparent; }
 
 /* ---------- Dialogs ---------- */
@@ -1309,14 +1309,14 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
 .studio-dialog header { display: flex; align-items: flex-start; justify-content: space-between; padding: 22px 22px 14px; }
 .studio-dialog h2 { margin: 3px 0 0; font-size: 21px; font-weight: 650; letter-spacing: -0.015em; }
 .studio-dialog header > button { width: 28px; height: 28px; border: 0; padding: 0; color: var(--muted); background: transparent; font-size: 20px; }
-.studio-dialog header p { margin: 4px 0 0; color: var(--muted); font-size: 9px; }
+.studio-dialog header p { margin: 4px 0 0; color: var(--muted); font-size: 10.5px; }
 .studio-dialog label { display: grid; gap: 5px; margin: 9px 0; color: var(--muted); font-size: 11px; }
 .studio-dialog label > span { display: flex; justify-content: space-between; }
 .studio-dialog input { width: 100%; min-height: 36px; border: 1px solid var(--line); border-radius: 9px; outline: 0; padding: 8px 10px; color: var(--ink); background: var(--surface-control); }
 .studio-dialog input:focus { border-color: var(--line-strong); box-shadow: 0 0 0 3px var(--accent-soft); }
 .studio-dialog > .segmented, .studio-dialog > label, .dialog-status { margin-inline: 18px; }
 .studio-dialog > .segmented { border-radius: 8px; padding: 3px; background: var(--surface-subtle); }
-.dialog-status { display: flex; align-items: center; gap: 7px; border: 1px solid var(--line); border-radius: 8px; margin-block: 10px; padding: 8px 9px; color: var(--muted); background: var(--surface); font-size: 9px; }
+.dialog-status { display: flex; align-items: center; gap: 7px; border: 1px solid var(--line); border-radius: 8px; margin-block: 10px; padding: 8px 9px; color: var(--muted); background: var(--surface); font-size: 10.5px; }
 .dialog-status span { width: 7px; height: 7px; flex: 0 0 auto; border-radius: 50%; }
 .dialog-status span.online { background: var(--success); }
 .dialog-status span.offline { background: var(--danger); }
@@ -1324,16 +1324,16 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
 .studio-dialog footer .primary { border-color: var(--accent); background: var(--accent); }
 
 .model-browser-dialog { width: min(620px, 100%); grid-template-rows: auto auto minmax(220px, 52vh) auto; overflow: hidden; }
-.model-browser-location { display: grid; grid-template-columns: auto minmax(0, 1fr) auto auto; align-items: center; gap: 7px; border-block: 1px solid var(--line-soft); padding: 9px 18px; color: var(--muted); background: var(--surface-overlay); font-size: 9px; }
-.model-browser-location input { min-width: 0; height: 30px; border-color: var(--line-soft); border-radius: 7px; padding-inline: 10px; color: var(--ink); background: var(--surface); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 9px; }
+.model-browser-location { display: grid; grid-template-columns: auto minmax(0, 1fr) auto auto; align-items: center; gap: 7px; border-block: 1px solid var(--line-soft); padding: 9px 18px; color: var(--muted); background: var(--surface-overlay); font-size: 10.5px; }
+.model-browser-location input { min-width: 0; height: 30px; border-color: var(--line-soft); border-radius: 7px; padding-inline: 10px; color: var(--ink); background: var(--surface); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 10.5px; }
 .model-browser-location button { min-height: 30px; padding: 6px 10px; }
 .model-browser-location span { color: var(--accent-ink); }
 .model-browser-list { min-height: 0; overflow-y: auto; padding: 7px 10px; }
 .model-browser-list > button { display: grid; width: 100%; grid-template-columns: 18px minmax(0, 1fr) auto; align-items: center; gap: 8px; border: 0; padding: 9px 10px; color: var(--ink-soft); background: transparent; text-align: left; }
 .model-browser-list > button:hover { border-color: transparent; background: var(--surface-subtle); }
 .model-browser-list > button span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.model-browser-list > button b { color: var(--muted); font-size: 8px; font-weight: 600; }
-.model-browser-list > p { margin: 28px 12px; color: var(--muted); text-align: center; font-size: 9px; }
+.model-browser-list > button b { color: var(--muted); font-size: 10px; font-weight: 600; }
+.model-browser-list > p { margin: 28px 12px; color: var(--muted); text-align: center; font-size: 10.5px; }
 
 /* ---------- Fatal error ---------- */
 

--- a/MFQStudio/src/styles.css
+++ b/MFQStudio/src/styles.css
@@ -1,1430 +1,20 @@
+/* MFQ Studio design system.
+   One token set (light + dark) and one component layer, ordered by surface:
+   tokens → base → shell/sidebar → page column → shared components →
+   dashboard pages → lab pages → chat → dialogs → responsive. */
+
+/* ---------- Design tokens ---------- */
+
 :root {
   color: var(--ink);
   background: var(--canvas);
+  color-scheme: light;
   font-family: "SF Pro Text", "SF Pro Display", -apple-system, BlinkMacSystemFont,
     "PingFang SC", "Noto Sans SC", "Segoe UI", sans-serif;
-  font-size: 13px;
+  font-size: 14px;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
-  --ink: #1b1d1e;
-  --ink-strong: #202223;
-  --ink-soft: #4a4e4c;
-  --muted: #737676;
-  --muted-light: #9a9d9c;
-  --line: #dedfda;
-  --line-strong: #c9cbc5;
-  --line-soft: #ebebe7;
-  --canvas: #f5f5f2;
-  --surface: #ffffff;
-  --surface-control: #fbfbfa;
-  --surface-subtle: #f0f1ed;
-  --surface-hover: #ebede8;
-  --surface-active: #f7f7f4;
-  --surface-inset: #f4f4f1;
-  --surface-overlay: rgb(255 255 255 / 88%);
-  --surface-user: #edede9;
-  --panel-surface: #eeefeb;
-  --panel-control: #e8e9e4;
-  --panel-line: rgb(68 72 70 / 9%);
-  --panel-overlap-line: rgb(68 72 70 / 14%);
-  --accent: #9a5d31;
-  --accent-hover: #7f4823;
-  --accent-soft: #f2e7dd;
-  --accent-border: #ddc4b2;
-  --accent-ink: #7c4928;
-  --on-accent: #ffffff;
-  --sidebar: #17191a;
-  --sidebar-surface: #202223;
-  --sidebar-hover: #292b2c;
-  --sidebar-line: #303233;
-  --success: #5a9a70;
-  --success-soft: #edf5ef;
-  --danger: #ad4b45;
-  --danger-soft: #faeeee;
-  --scrollbar: #c3c5c0;
-  --shadow-sm: 0 1px 2px rgb(20 22 22 / 4%), 0 3px 12px rgb(20 22 22 / 3%);
-  --shadow-md: 0 14px 45px rgb(20 22 22 / 12%);
-}
 
-:root[data-theme="dark"] {
-  color-scheme: dark;
-  --ink: #ecefeb;
-  --ink-strong: #f4f6f3;
-  --ink-soft: #c0c5c1;
-  --muted: #929894;
-  --muted-light: #6f7672;
-  --line: #2a2f2c;
-  --line-strong: #3b423e;
-  --line-soft: #222725;
-  --canvas: #0d0f0f;
-  --surface: #141716;
-  --surface-control: #171b19;
-  --surface-subtle: #191d1b;
-  --surface-hover: #202522;
-  --surface-active: #1d221f;
-  --surface-inset: #101312;
-  --surface-overlay: rgb(15 18 17 / 88%);
-  --surface-user: #1e2320;
-  --panel-surface: #151917;
-  --panel-control: #1a1f1c;
-  --panel-line: rgb(224 232 226 / 7%);
-  --panel-overlap-line: rgb(224 232 226 / 11%);
-  --accent: #c87b45;
-  --accent-hover: #dd915a;
-  --accent-soft: rgb(200 123 69 / 14%);
-  --accent-border: rgb(200 123 69 / 38%);
-  --accent-ink: #e2a170;
-  --on-accent: #15100d;
-  --sidebar: #090b0b;
-  --sidebar-surface: #111413;
-  --sidebar-hover: #181c1a;
-  --sidebar-line: #202522;
-  --success: #67a67c;
-  --success-soft: rgb(103 166 124 / 12%);
-  --danger: #d16c65;
-  --danger-soft: rgb(209 108 101 / 12%);
-  --scrollbar: #343a37;
-  --shadow-sm: 0 1px 0 rgb(255 255 255 / 2%), 0 8px 22px rgb(0 0 0 / 12%);
-  --shadow-md: 0 24px 70px rgb(0 0 0 / 38%);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root[data-theme="system"] {
-    color-scheme: dark;
-    --ink: #ecefeb;
-    --ink-strong: #f4f6f3;
-    --ink-soft: #c0c5c1;
-    --muted: #929894;
-    --muted-light: #6f7672;
-    --line: #2a2f2c;
-    --line-strong: #3b423e;
-    --line-soft: #222725;
-    --canvas: #0d0f0f;
-    --surface: #141716;
-    --surface-control: #171b19;
-    --surface-subtle: #191d1b;
-    --surface-hover: #202522;
-    --surface-active: #1d221f;
-    --surface-inset: #101312;
-    --surface-overlay: rgb(15 18 17 / 88%);
-    --surface-user: #1e2320;
-    --panel-surface: #151917;
-    --panel-control: #1a1f1c;
-    --panel-line: rgb(224 232 226 / 7%);
-    --panel-overlap-line: rgb(224 232 226 / 11%);
-    --accent: #c87b45;
-    --accent-hover: #dd915a;
-    --accent-soft: rgb(200 123 69 / 14%);
-    --accent-border: rgb(200 123 69 / 38%);
-    --accent-ink: #e2a170;
-    --on-accent: #15100d;
-    --sidebar: #090b0b;
-    --sidebar-surface: #111413;
-    --sidebar-hover: #181c1a;
-    --sidebar-line: #202522;
-    --success: #67a67c;
-    --success-soft: rgb(103 166 124 / 12%);
-    --danger: #d16c65;
-    --danger-soft: rgb(209 108 101 / 12%);
-    --scrollbar: #343a37;
-    --shadow-sm: 0 1px 0 rgb(255 255 255 / 2%), 0 8px 22px rgb(0 0 0 / 12%);
-    --shadow-md: 0 24px 70px rgb(0 0 0 / 38%);
-  }
-}
-
-* { box-sizing: border-box; }
-html, body, #root { min-width: 320px; min-height: 100%; margin: 0; }
-body { overflow: hidden; }
-button, input, textarea, select { font: inherit; }
-button { cursor: pointer; }
-button:disabled { cursor: not-allowed; opacity: 0.45; }
-button, input, textarea, select { transition: border-color 130ms ease, background-color 130ms ease, color 130ms ease, box-shadow 130ms ease; }
-button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-visible, summary:focus-visible {
-  outline: 2px solid rgb(154 93 49 / 28%);
-  outline-offset: 2px;
-}
-::selection { color: #fff; background: #a4673c; }
-* { scrollbar-width: thin; scrollbar-color: var(--scrollbar) transparent; }
-
-.ui-icon {
-  display: block;
-  flex: 0 0 auto;
-  stroke: currentColor;
-  stroke-width: 1.7;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-}
-
-.app-shell {
-  display: grid;
-  grid-template-columns: 232px minmax(0, 1fr);
-  width: 100%;
-  height: 100vh;
-  height: 100dvh;
-  overflow: hidden;
-}
-
-.sidebar {
-  position: relative;
-  z-index: 10;
-  display: flex;
-  min-height: 0;
-  flex-direction: column;
-  border-right: 1px solid #111314;
-  padding: 13px 10px 10px;
-  color: #f1f2ef;
-  background: var(--sidebar);
-}
-
-.brand { display: flex; align-items: center; gap: 10px; padding: 2px 7px 13px; }
-.brand img { width: 30px; height: 30px; border-radius: 7px; }
-.brand div { display: flex; align-items: baseline; gap: 5px; }
-.brand strong { font-size: 15px; font-weight: 680; letter-spacing: -0.015em; }
-.brand span { color: #818586; font-size: 10px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; }
-
-.new-session {
-  display: flex;
-  width: 100%;
-  min-height: 34px;
-  align-items: center;
-  gap: 8px;
-  border: 1px solid #404344;
-  border-radius: 8px;
-  padding: 7px 9px;
-  color: #f4f4f1;
-  background: #252728;
-  font-weight: 560;
-  font-size: 10px;
-  text-align: left;
-}
-.new-session:hover { border-color: #555859; background: #2d2f30; }
-
-.sidebar-divider { height: 1px; flex: 0 0 auto; margin: 0 5px; background: var(--sidebar-line); }
-.primary-nav { display: grid; gap: 3px; margin: 11px 0; }
-.primary-nav button {
-  display: flex;
-  min-height: 33px;
-  align-items: center;
-  gap: 9px;
-  border: 0;
-  border-radius: 7px;
-  padding: 7px 9px;
-  color: #aeb1b0;
-  background: transparent;
-  font-size: 12px;
-  text-align: left;
-}
-.primary-nav button:hover { color: #f4f5f2; background: #222425; }
-.primary-nav button.active { color: #fff; background: var(--sidebar-hover); }
-.primary-nav button.active .ui-icon { color: #d4a27d; }
-.primary-nav button span {
-  min-width: 20px;
-  margin-left: auto;
-  border: 1px solid #343637;
-  border-radius: 999px;
-  padding: 1px 6px;
-  color: #909493;
-  background: #131516;
-  font-size: 9px;
-  text-align: center;
-}
-
-.chat-sidebar-section { display: none; min-height: 0; flex: 1; flex-direction: column; }
-.chat-sidebar-section.visible { display: flex; }
-
-.assistant-heading, .context-sidebar-heading { display: flex; align-items: center; justify-content: space-between; padding: 13px 7px 8px; color: #767a7a; font-size: 9px; font-weight: 700; letter-spacing: 0.09em; text-transform: uppercase; }
-.assistant-heading small { color: #616565; font-size: 8px; }
-.assistant-list { display: grid; max-height: min(168px, 24vh); flex: 0 1 auto; gap: 2px; margin-bottom: 8px; overflow-y: auto; }
-.assistant-row { position: relative; display: grid; min-width: 0; min-height: 39px; grid-template-columns: minmax(0, 1fr) auto; align-items: center; border-radius: 7px; }
-.assistant-row:hover { background: #222425; }
-.assistant-row.active { background: var(--sidebar-hover); }
-.assistant-main { display: grid; min-width: 0; grid-template-columns: 27px minmax(0, 1fr); align-items: center; gap: 8px; border: 0; padding: 6px 7px; color: #aeb1b0; background: transparent; text-align: left; }
-.assistant-row:hover .assistant-main, .assistant-row.active .assistant-main { color: #fff; }
-.assistant-main > span { display: grid; width: 27px; height: 27px; place-items: center; border: 1px solid #3a3d3d; border-radius: 7px; color: #d2a07b; background: #1b1d1e; font-size: 10px; font-weight: 680; }
-.assistant-main > div { display: grid; min-width: 0; gap: 2px; }
-.assistant-list strong { overflow: hidden; font-size: 10px; font-weight: 620; text-overflow: ellipsis; white-space: nowrap; }
-.assistant-list small { color: #717575; font-size: 8px; }
-.assistant-edit { display: none; width: 23px; height: 23px; place-items: center; border: 0; border-radius: 5px; margin-right: 4px; padding: 0; color: #777b7a; background: transparent; }
-.assistant-row:hover .assistant-edit, .assistant-row.active .assistant-edit { display: grid; }
-.assistant-edit:hover { color: #f2f3f0; background: #383a3b; }
-.chat-sidebar-section > .new-session { min-height: 31px; margin-bottom: 11px; }
-
-.context-sidebar-section { display: none; min-height: 0; flex: 1; flex-direction: column; }
-.context-sidebar-section.visible { display: flex; }
-.context-sidebar-heading { display: grid; justify-content: stretch; gap: 3px; border-bottom: 1px solid var(--sidebar-line); padding: 8px 7px 15px; letter-spacing: 0; text-transform: none; }
-.context-sidebar-heading strong { color: #e2e4e1; font-size: 12px; font-weight: 640; }
-.context-sidebar-heading small { color: #747878; font-size: 8px; font-weight: 500; }
-.context-nav { display: grid; gap: 3px; padding-top: 13px; }
-.context-nav button { display: flex; min-height: 32px; align-items: center; gap: 8px; border: 0; border-radius: 7px; padding: 7px 9px; color: #a8acab; background: transparent; font-size: 10px; text-align: left; }
-.context-nav button:hover { color: #f3f4f1; background: var(--sidebar-hover); }
-.context-nav button.active { color: #fff; background: var(--sidebar-hover); }
-
-.session-create { flex: 0 0 auto; border-block: 1px solid var(--sidebar-line); padding: 0 5px; }
-.session-create[open] { display: grid; gap: 7px; padding-bottom: 11px; }
-.session-create summary { cursor: pointer; padding: 9px 2px; color: #767a7a; font-size: 8px; font-weight: 650; }
-.session-create label, .history-heading { color: #767a7a; font-size: 9px; font-weight: 700; letter-spacing: 0.09em; text-transform: uppercase; }
-.session-create select {
-  width: 100%;
-  min-width: 0;
-  border: 1px solid #3b3e3f;
-  border-radius: 7px;
-  outline: 0;
-  padding: 7px 8px;
-  color: #e5e6e3;
-  background: #202223;
-  font-size: 10px;
-}
-.session-create select:hover { border-color: #505354; }
-.open-local-model {
-  display: flex;
-  min-height: 32px;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  border: 1px solid var(--sidebar-line);
-  border-radius: 7px;
-  padding: 6px 8px;
-  color: #d2d5d2;
-  background: #2a2c2d;
-  font-size: 9px;
-}
-.open-local-model:hover { border-color: #555859; background: #303233; }
-.mode-picker, .segmented { display: grid; grid-template-columns: repeat(3, 1fr); gap: 3px; }
-.mode-picker { border-radius: 8px; padding: 3px; background: #101213; }
-.mode-picker button {
-  border: 0;
-  border-radius: 6px;
-  padding: 6px 2px;
-  color: #858988;
-  background: transparent;
-  font-size: 9px;
-}
-.mode-picker button:hover { color: #d7d9d6; }
-.mode-picker button[aria-pressed="true"] { color: #f3f4f1; background: #323536; box-shadow: 0 1px 3px rgb(0 0 0 / 25%); }
-
-.history-heading { display: flex; align-items: center; justify-content: space-between; padding: 15px 7px 8px; }
-.history-heading > div { display: flex; gap: 1px; }
-.history-heading button { display: grid; width: 23px; height: 23px; place-items: center; border: 0; border-radius: 6px; color: #747878; background: transparent; }
-.history-heading button:hover { color: #d8dad7; background: #262829; }
-.session-list { min-height: 0; flex: 1; overflow-y: auto; padding-right: 1px; }
-.session-row { position: relative; display: grid; min-height: 41px; grid-template-columns: minmax(0, 1fr) auto; align-items: center; border-radius: 7px; margin: 1px 0; }
-.session-row:hover { background: #222425; }
-.session-row.active { background: #2a2c2d; box-shadow: inset 2px 0 #b4774d; }
-.session-main { display: grid; min-width: 0; gap: 2px; border: 0; padding: 7px 8px; color: #d2d4d1; background: transparent; font-size: 11px; text-align: left; }
-.session-main span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.session-main small { color: #737777; font-size: 9px; }
-.session-row.active .session-main small { color: #9a9d9c; }
-.session-row > input { min-width: 0; margin: 6px; border: 1px solid #875738; border-radius: 6px; outline: none; padding: 5px 7px; color: white; background: #111314; }
-.session-actions { display: none; padding-right: 4px; }
-.session-row:hover .session-actions, .session-row.active .session-actions, .session-row:focus-within .session-actions { display: flex; }
-.session-actions button { display: grid; width: 23px; height: 23px; place-items: center; border: 0; border-radius: 5px; padding: 0; color: #777b7a; background: transparent; }
-.session-actions button:hover { color: #f2f3f0; background: #383a3b; }
-.empty-note { display: block; padding: 12px 8px; color: #737777; font-size: 10px; }
-
-.mobile-scrim { display: none; }
-.workspace { display: grid; min-width: 0; min-height: 0; grid-template-rows: 54px minmax(0, 1fr); background: var(--canvas); }
-.topbar {
-  position: relative;
-  z-index: 5;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 18px;
-  border-bottom: 1px solid var(--line);
-  padding: 0 18px;
-  background: var(--surface-overlay);
-  backdrop-filter: blur(16px) saturate(1.2);
-}
-.topbar-identity { display: flex; min-width: 0; align-items: center; gap: 9px; }
-.sidebar-toggle { display: none; }
-.topbar-model { display: grid; min-width: 0; gap: 1px; }
-.topbar-model span { overflow: hidden; max-width: min(34vw, 450px); color: var(--ink-strong); font-size: 12px; font-weight: 630; text-overflow: ellipsis; white-space: nowrap; }
-.topbar-model small { overflow: hidden; color: var(--muted-light); font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
-.topbar-actions { display: flex; min-width: 0; align-items: center; gap: 6px; }
-.topbar-actions > button, .sidebar-toggle {
-  width: 31px;
-  height: 31px;
-  place-items: center;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  padding: 0;
-  color: var(--muted);
-  background: var(--surface);
-}
-.topbar-actions > button { display: grid; }
-.topbar-actions > button:hover, .sidebar-toggle:hover { border-color: var(--line-strong); color: var(--ink); background: var(--surface-subtle); }
-.theme-switcher { display: grid; grid-template-columns: repeat(3, auto); gap: 2px; border: 1px solid var(--line); border-radius: 9px; padding: 2px; background: var(--surface-subtle); }
-.theme-switcher button { display: flex; min-height: 25px; align-items: center; gap: 4px; border: 0; border-radius: 6px; padding: 4px 7px; color: var(--muted); background: transparent; font-size: 8px; font-weight: 620; }
-.theme-switcher button:hover { color: var(--ink); background: var(--surface-hover); }
-.theme-switcher button[aria-pressed="true"] { color: var(--accent-ink); background: var(--surface); box-shadow: var(--shadow-sm); }
-.capabilities { display: flex; max-width: 380px; gap: 3px; overflow: hidden; }
-.capabilities span { border: 1px solid var(--line); border-radius: 999px; padding: 3px 7px; color: var(--muted); background: var(--surface-subtle); font-size: 8px; font-weight: 560; white-space: nowrap; }
-.capabilities span.muted { opacity: 0.42; }
-.quick-metrics { display: flex; gap: 12px; border-inline: 1px solid var(--line); margin-inline: 3px; padding-inline: 12px; }
-.quick-metrics span { display: grid; color: var(--muted-light); font-size: 7px; font-weight: 650; letter-spacing: 0.055em; line-height: 1.2; text-transform: uppercase; }
-.quick-metrics b { color: var(--ink-soft); font-size: 10px; font-weight: 620; letter-spacing: 0; text-transform: none; }
-
-.chat-view { display: grid; min-height: 0; grid-template-rows: minmax(0, 1fr) auto auto; background: var(--canvas); }
-.message-scroller { overflow-y: auto; }
-.message-scroller { min-height: 0; overscroll-behavior: contain; }
-.message-list { width: min(860px, 100%); min-height: 100%; margin: 0 auto; padding: 28px 28px 22px; }
-.welcome { display: grid; place-items: center; max-width: 570px; margin: 15vh auto 0; text-align: center; }
-.welcome img { width: 48px; height: 48px; margin-bottom: 14px; border: 1px solid var(--line); border-radius: 11px; box-shadow: var(--shadow-sm); }
-.welcome h1, .welcome h2 { margin: 0; font-size: 22px; font-weight: 650; letter-spacing: -0.025em; }
-.welcome h2 { font-size: 18px; }
-.welcome p { max-width: 460px; margin: 8px 0 0; color: var(--muted); font-size: 11px; }
-.welcome.compact { margin-top: 18vh; }
-.open-model-primary {
-  display: inline-flex;
-  min-height: 38px;
-  align-items: center;
-  gap: 7px;
-  border: 1px solid var(--accent);
-  border-radius: 9px;
-  margin-top: 19px;
-  padding: 8px 14px;
-  color: var(--on-accent);
-  background: var(--accent);
-  font-size: 11px;
-  font-weight: 620;
-  box-shadow: var(--shadow-sm);
-}
-.open-model-primary:hover { border-color: var(--accent-hover); background: var(--accent-hover); }
-.prompt-grid { display: grid; width: 100%; grid-template-columns: 1fr 1fr; gap: 7px; margin-top: 18px; }
-.prompt-grid button { border: 1px solid var(--line); border-radius: 10px; padding: 11px 12px; color: var(--ink-soft); background: var(--surface); font-size: 11px; box-shadow: var(--shadow-sm); }
-.prompt-grid button:hover { border-color: var(--line-strong); color: var(--ink); background: var(--surface-hover); transform: translateY(-1px); }
-
-.message { display: grid; grid-template-columns: 31px minmax(0, 1fr); gap: 10px; margin-bottom: 23px; }
-.message-user { grid-template-columns: minmax(0, 1fr) 31px; }
-.message-user .message-avatar { grid-column: 2; grid-row: 1; }
-.message-user .message-body {
-  grid-column: 1;
-  grid-row: 1;
-  justify-self: end;
-  width: fit-content;
-  max-width: min(640px, 92%);
-}
-.message-user .message-content {
-  border: 1px solid var(--line);
-  border-radius: 13px 4px 13px 13px;
-  padding: 9px 11px;
-  background: var(--surface-user);
-}
-.message-avatar { display: grid; width: 29px; height: 29px; place-items: center; border: 1px solid var(--line); border-radius: 8px; color: var(--muted); background: var(--surface); font-size: 8px; box-shadow: var(--shadow-sm); }
-.message-avatar img { width: 21px; height: 21px; }
-.message-body { min-width: 0; }
-.message-meta { display: flex; align-items: baseline; gap: 7px; margin-bottom: 5px; }
-.message-meta strong { color: var(--ink-soft); font-size: 10px; font-weight: 650; }
-.message-meta span { color: var(--muted-light); font-size: 8px; }
-.message-actions { display: flex; gap: 2px; margin-top: 7px; opacity: 0; transition: opacity 120ms; }
-.message-user .message-actions { justify-content: flex-end; }
-.message:hover .message-actions, .message:focus-within .message-actions { opacity: 1; }
-.message-actions button { border: 0; border-radius: 5px; padding: 3px 6px; color: #949796; background: transparent; font-size: 9px; }
-.message-actions button:hover { color: var(--accent); background: var(--accent-soft); }
-.response-metrics { margin-top: 7px; color: var(--muted-light); font-size: 8px; }
-.response-metrics summary { display: flex; width: fit-content; cursor: pointer; gap: 8px; list-style: none; }
-.response-metrics summary::-webkit-details-marker { display: none; }
-.response-metrics summary span + span { border-left: 1px solid var(--line); padding-left: 8px; }
-.response-metrics > div { display: flex; flex-wrap: wrap; gap: 5px 10px; margin-top: 6px; }
-.live-message .message-avatar { box-shadow: 0 0 0 3px rgb(154 93 49 / 8%); }
-
-.rich-text { color: var(--ink-soft); font-size: 12.5px; line-height: 1.66; overflow-wrap: anywhere; }
-.rich-text > :first-child { margin-top: 0; }
-.rich-text > :last-child { margin-bottom: 0; }
-.rich-text p, .rich-text ul, .rich-text ol, .rich-text pre, .rich-text blockquote { margin: 0.68em 0; }
-.rich-text ul, .rich-text ol { padding-left: 1.7em; }
-.rich-text li + li { margin-top: 0.18em; }
-.rich-text h1, .rich-text h2, .rich-text h3 { margin: 1.15em 0 0.42em; color: var(--ink-strong); font-weight: 670; letter-spacing: -0.015em; }
-.rich-text h1 { font-size: 1.48em; }
-.rich-text h2 { font-size: 1.26em; }
-.rich-text h3 { font-size: 1.1em; }
-.rich-text code { border: 1px solid var(--line); border-radius: 5px; padding: 0.1em 0.32em; color: var(--accent-ink); background: var(--surface-subtle); font-family: "SFMono-Regular", "Cascadia Code", Consolas, monospace; font-size: 0.88em; }
-.rich-text pre { position: relative; overflow-x: auto; border: 1px solid #343737; border-radius: 10px; padding: 34px 13px 13px; color: #e9ebe8; background: #1c1e1f; box-shadow: 0 5px 16px rgb(20 22 22 / 8%); }
-.rich-text pre code { border: 0; padding: 0; color: inherit; background: transparent; }
-.code-copy { position: absolute; top: 6px; right: 7px; border: 1px solid #414445; border-radius: 6px; padding: 3px 7px; color: #b9bcba; background: #292b2c; font-size: 8px; }
-.code-copy:hover { color: #fff; background: #343637; }
-.rich-text blockquote { border-left: 2px solid var(--accent); margin-left: 0; padding-left: 12px; color: var(--muted); }
-.rich-text a { color: #8d532c; text-underline-offset: 2px; }
-.rich-text table { width: 100%; border-collapse: separate; border-spacing: 0; overflow: hidden; border: 1px solid var(--line); border-radius: 8px; }
-.rich-text th, .rich-text td { border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); padding: 7px 9px; text-align: left; }
-.rich-text tr:last-child td { border-bottom: 0; }
-.rich-text th:last-child, .rich-text td:last-child { border-right: 0; }
-.rich-text th { background: var(--surface-subtle); font-weight: 650; }
-.reasoning { border: 1px solid var(--line); border-radius: 9px; margin: 3px 0 10px; padding: 8px 10px; color: var(--muted); background: var(--surface-subtle); }
-.reasoning summary { cursor: pointer; color: var(--muted); font-size: 10px; font-weight: 620; }
-.reasoning .rich-text { margin-top: 8px; color: var(--muted); font-size: 11.5px; }
-.tool-call { overflow-x: auto; border: 1px solid #373a3a; border-radius: 9px; padding: 10px; color: #e3e5e2; background: #202223; font-size: 10px; }
-.tool-call pre { margin: 0; color: inherit; white-space: pre-wrap; }
-.tool-call button { border: 1px solid #555958; border-radius: 6px; margin-top: 8px; padding: 4px 7px; color: #f1f2ef; background: #343738; font-size: 9px; }
-.tool-confirm { margin-top: 6px; }
-.tool-confirm button { border: 1px solid var(--line-strong); border-radius: 7px; padding: 5px 8px; color: var(--accent); background: var(--accent-soft); font-size: 9px; }
-.message-media { display: block; max-width: min(560px, 100%); max-height: 440px; border: 1px solid var(--line); border-radius: 10px; margin: 4px 0 10px; background: var(--surface-subtle); object-fit: contain; }
-.message-media-status { display: block; width: min(360px, 100%); border: 1px solid var(--line); border-radius: 9px; margin: 4px 0 10px; padding: 10px; color: var(--muted); background: var(--surface-subtle); font-size: 9px; }
-.fatal-error { min-height: 100vh; display: grid; place-items: center; padding: 32px; background: var(--canvas); color: var(--ink); }
-.fatal-error section { width: min(640px, 100%); padding: 28px; border: 1px solid var(--line); border-radius: 16px; background: var(--surface); box-shadow: var(--shadow-md); }
-.fatal-error h1 { margin: 8px 0 12px; font-size: 24px; }
-.fatal-error p { color: var(--muted); line-height: 1.6; }
-.fatal-error pre { overflow: auto; margin: 18px 0; padding: 14px; border-radius: 9px; background: var(--surface-subtle); white-space: pre-wrap; word-break: break-word; }
-.media-image { width: auto; }
-.media-video { width: min(560px, 100%); }
-.message-audio { width: min(420px, 100%); height: 34px; margin-top: 9px; }
-.message-document { display: flex; width: min(360px, 100%); align-items: center; gap: 9px; border: 1px solid var(--line); border-radius: 9px; margin: 5px 0; padding: 8px; color: inherit; background: var(--surface); font: inherit; text-align: left; cursor: pointer; }
-.message-document:disabled { cursor: progress; opacity: 0.7; }
-.message-document > span { display: grid; width: 31px; height: 31px; place-items: center; border-radius: 7px; color: var(--accent); background: var(--accent-soft); font-size: 8px; font-weight: 700; }
-.message-document div { display: grid; min-width: 0; gap: 2px; }
-.message-document strong { overflow: hidden; color: var(--ink); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
-.message-document small { color: var(--muted-light); font-size: 8px; }
-.thinking { display: flex; gap: 4px; padding: 10px 0; }
-.thinking i { width: 5px; height: 5px; border-radius: 50%; background: #a66b43; animation: bounce 1s infinite ease-in-out; }
-.thinking i:nth-child(2) { animation-delay: 120ms; }
-.thinking i:nth-child(3) { animation-delay: 240ms; }
-@keyframes bounce { 50% { opacity: 0.35; transform: translateY(-3px); } }
-
-.message-editor { display: grid; gap: 7px; }
-.message-editor textarea { width: 100%; min-height: 90px; resize: vertical; border: 1px solid var(--line); border-radius: 8px; outline: none; padding: 9px; color: var(--ink); background: var(--surface-control); }
-.message-editor > div { display: flex; justify-content: flex-end; gap: 6px; }
-.message-editor button, .studio-dialog button { border: 1px solid var(--line); border-radius: 7px; padding: 7px 10px; color: var(--ink-soft); background: var(--surface); }
-.message-editor button:hover, .studio-dialog button:hover { border-color: var(--line-strong); background: var(--surface-subtle); }
-button.primary { border-color: var(--accent); color: var(--on-accent); background: var(--accent); }
-button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent); background: var(--accent-hover); }
-
-.error-banner { display: flex; width: min(812px, calc(100% - 40px)); max-height: 148px; align-items: flex-start; justify-content: space-between; gap: 10px; overflow: auto; border: 1px solid var(--danger); border-radius: 8px; margin: 0 auto 8px; padding: 8px 10px; color: var(--danger); background: var(--danger-soft); font-size: 10px; }
-.error-banner span { min-width: 0; overflow-wrap: anywhere; white-space: pre-wrap; }
-.error-banner button { border: 0; color: inherit; background: transparent; }
-.composer-region { width: min(860px, 100%); margin: 0 auto; padding: 0 28px 11px; }
-.composer-region > p { margin: 6px 0 0; color: var(--muted-light); font-size: 8px; text-align: center; }
-.voice-component-banner { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 7px 12px; border: 1px solid var(--accent-border); border-radius: 10px; margin-bottom: 8px; padding: 9px 10px; color: var(--accent-ink); background: var(--accent-soft); }
-.voice-component-banner > div { display: grid; min-width: 0; gap: 2px; }
-.voice-component-banner strong { font-size: 10px; }
-.voice-component-banner span { overflow: hidden; color: var(--muted); font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
-.voice-component-banner progress { width: 100%; height: 4px; grid-column: 1 / -1; accent-color: var(--accent); }
-.voice-component-banner button { grid-column: 2; grid-row: 1; border: 1px solid var(--accent-border); border-radius: 7px; padding: 6px 9px; color: var(--on-accent); background: var(--accent); font-size: 9px; font-weight: 650; }
-.voice-component-banner button:disabled { cursor: progress; opacity: 0.65; }
-.composer { overflow: hidden; border: 1px solid var(--line-strong); border-radius: 13px; background: var(--surface); box-shadow: var(--shadow-sm); }
-.composer:focus-within { border-color: #b98a69; box-shadow: 0 0 0 3px rgb(154 93 49 / 8%), 0 8px 26px rgb(25 28 28 / 8%); }
-.composer textarea { display: block; width: 100%; min-height: 42px; max-height: 180px; resize: none; border: 0; outline: 0; padding: 11px 12px 5px; color: var(--ink); background: transparent; font-size: 12px; line-height: 1.5; }
-.composer textarea::placeholder { color: #a4a7a5; }
-.composer-toolbar { display: flex; min-height: 39px; align-items: center; gap: 4px; padding: 4px 6px 6px; }
-.composer-toolbar > button, .composer-toolbar select { display: flex; height: 28px; align-items: center; justify-content: center; gap: 5px; border: 1px solid var(--line); border-radius: 7px; padding: 0 7px; color: var(--muted); background: var(--surface-subtle); font-size: 9px; }
-.composer-toolbar > button:hover, .composer-toolbar select:hover { border-color: var(--line-strong); color: var(--ink); background: var(--surface-hover); }
-.composer-toolbar > button[aria-pressed="true"] { border-color: var(--accent-border); color: var(--accent-ink); background: var(--accent-soft); }
-.composer-toolbar .voice-button { position: relative; width: 28px; padding: 0; border-radius: 50%; }
-.voice-button span { position: absolute; inset: 8px; border-radius: 50%; background: #a4673c; transform: scale(calc(0.82 + var(--voice-level) * 0.38)); box-shadow: 0 0 calc(4px + var(--voice-level) * 9px) rgb(164 103 60 / 48%); }
-.composer-hint { margin-left: auto; color: #9b9e9c; font-size: 8px; }
-.composer-toolbar .send-button { width: 29px; border-color: var(--accent); border-radius: 50%; padding: 0; color: var(--on-accent); background: var(--accent); }
-.composer-toolbar .send-button:hover { border-color: var(--accent-hover); color: var(--on-accent); background: var(--accent-hover); }
-.composer-toolbar .send-button.stop { border-color: #9d4742; background: #9d4742; }
-.attachment-tray { display: flex; gap: 7px; overflow-x: auto; padding: 9px 9px 0; }
-.attachment-chip { position: relative; display: grid; min-width: 178px; grid-template-columns: 36px minmax(0, 1fr) 20px; align-items: center; gap: 7px; border: 1px solid var(--line); border-radius: 8px; padding: 5px; background: var(--surface-subtle); }
-.attachment-chip > img, .attachment-chip > video, .attachment-chip > span { display: grid; width: 36px; height: 36px; place-items: center; border-radius: 6px; background: var(--surface-hover); object-fit: cover; }
-.attachment-chip div { display: grid; min-width: 0; }
-.attachment-chip strong { overflow: hidden; font-size: 9px; font-weight: 620; text-overflow: ellipsis; white-space: nowrap; }
-.attachment-chip small { color: var(--muted); font-size: 8px; }
-.attachment-chip button { border: 0; color: #929593; background: transparent; }
-
-.dashboard-view, .lab-view { min-height: 0; overflow-y: auto; padding: 31px clamp(24px, 4.5vw, 64px) 48px; background: var(--canvas); }
-.dashboard-view > *, .lab-view > * { width: min(1240px, 100%); margin-inline: auto; }
-.page-heading { display: flex; align-items: flex-start; justify-content: space-between; margin-bottom: 21px; }
-.page-heading p, .panel-heading p { margin: 0; color: #986744; font-size: 8px; font-weight: 700; letter-spacing: 0.11em; text-transform: uppercase; }
-.page-heading h1 { margin: 3px 0; font-size: 22px; font-weight: 650; letter-spacing: -0.025em; }
-.page-heading span { color: var(--muted); font-size: 10px; }
-.page-heading > button { display: grid; width: 32px; height: 32px; place-items: center; border: 1px solid var(--line); border-radius: 8px; color: var(--muted); background: var(--surface); }
-.page-heading > button:hover { border-color: var(--line-strong); color: var(--ink); background: var(--surface-subtle); }
-.metric-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 9px; margin-bottom: 10px; }
-.metric-grid article { display: grid; min-width: 0; border: 0; border-radius: 11px; padding: 13px; background: var(--panel-surface); box-shadow: none; }
-.metric-grid span { color: var(--muted); font-size: 9px; font-weight: 570; }
-.metric-grid strong { margin: 4px 0; font-size: 20px; font-weight: 630; letter-spacing: -0.025em; }
-.metric-grid small { color: var(--muted-light); font-size: 8px; }
-.dashboard-grid { display: grid; grid-template-columns: minmax(0, 2fr) minmax(260px, 1fr); gap: 10px; }
-.dashboard-lower-grid { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 10px; margin-top: 10px; }
-.dashboard-panel { border: 0; border-radius: 11px; padding: 15px; background: var(--panel-surface); box-shadow: none; }
-.panel-deck { position: relative; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 11px; }
-.panel-deck.single { grid-template-columns: 1fr; }
-.panel-deck.page-dashboard-overview { grid-template-columns: minmax(0, 2fr) minmax(260px, 1fr); }
-.panel-deck.page-dashboard-overview > [data-panel-id="metrics"] { grid-column: 1 / -1; grid-row: 1; }
-.panel-deck.page-dashboard-overview > [data-panel-id="throughput"] { grid-column: 1; grid-row: 2 / span 2; }
-.panel-deck.page-dashboard-overview > [data-panel-id="runtime"] { grid-column: 2; grid-row: 2; align-self: start; }
-.panel-deck.page-dashboard-overview > [data-panel-id="request"] { grid-column: 2; grid-row: 3; align-self: start; }
-.panel-deck.page-dashboard-overview > [data-panel-id="request"] .request-stats { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-.panel-deck.page-dashboard-models > [data-panel-id="catalog"] { grid-column: 1; grid-row: 1; }
-.panel-deck.page-dashboard-models > [data-panel-id="requests"] { grid-column: 2; grid-row: 1; }
-.panel-deck.page-dashboard-models > [data-panel-id="jobs"] { grid-column: 1; grid-row: 2; }
-.panel-deck.page-dashboard-models > [data-panel-id="logs"] { grid-column: 2; grid-row: 2; }
-.panel-deck.page-lab-evaluations > [data-panel-id="results"] { grid-column: 1; }
-.panel-deck.page-lab-evaluations > [data-panel-id="datasets"] { grid-column: 2; }
-.panel-shell { position: relative; min-width: 0; overflow: hidden; container-type: inline-size; transition: opacity 140ms ease, transform 140ms ease; }
-.panel-overlap-layer { position: absolute; z-index: 2147483647; inset: 0; overflow: visible; pointer-events: none; }
-.panel-overlap-boundary { position: absolute; box-sizing: border-box; }
-.panel-overlap-boundary.edge-top { border-top: 1px solid var(--panel-overlap-line); }
-.panel-overlap-boundary.edge-right { border-right: 1px solid var(--panel-overlap-line); }
-.panel-overlap-boundary.edge-bottom { border-bottom: 1px solid var(--panel-overlap-line); }
-.panel-overlap-boundary.edge-left { border-left: 1px solid var(--panel-overlap-line); }
-.panel-overlap-boundary.edge-top.edge-left { border-top-left-radius: 11px; }
-.panel-overlap-boundary.edge-top.edge-right { border-top-right-radius: 11px; }
-.panel-overlap-boundary.edge-bottom.edge-right { border-bottom-right-radius: 11px; }
-.panel-overlap-boundary.edge-bottom.edge-left { border-bottom-left-radius: 11px; }
-.panel-shell.wide { grid-column: 1 / -1; }
-.panel-deck .panel-shell { transform: translate3d(var(--panel-x, 0), var(--panel-y, 0), 0); }
-.panel-shell > .dashboard-panel, .panel-shell > .metric-grid, .panel-shell > div > .dashboard-panel { width: 100%; height: 100%; margin: 0; }
-.panel-deck .panel-shell.dragging { opacity: 0.72; transform: translate3d(var(--panel-x), var(--panel-y), 0) scale(0.992); transition-duration: 0s; }
-.panel-deck .panel-shell.resizing { transition-duration: 0s; }
-.panel-drag, .panel-collapse { position: absolute; z-index: 2; top: 11px; display: grid; width: 23px; height: 23px; place-items: center; border: 0; border-radius: 6px; padding: 0; color: var(--muted-light); background: transparent; }
-.panel-drag { right: 38px; grid-template-columns: repeat(2, 2px); grid-template-rows: repeat(3, 2px); place-content: center; gap: 2px; cursor: grab; touch-action: none; user-select: none; -webkit-user-select: none; }
-.panel-drag:active { cursor: grabbing; }
-.panel-drag span { width: 2px; height: 2px; border-radius: 50%; background: currentColor; }
-.panel-collapse { right: 10px; font-size: 15px; line-height: 1; transition: transform 130ms ease; }
-.panel-drag:hover, .panel-collapse:hover { color: var(--ink); background: rgb(127 132 129 / 8%); }
-.panel-shell.collapsed .panel-collapse { transform: rotate(-90deg); }
-.panel-shell.collapsed > :not(.panel-drag):not(.panel-collapse) { height: 47px; min-height: 47px; overflow: hidden; }
-.panel-shell.collapsed .dashboard-panel, .panel-shell.collapsed .metric-grid { padding-bottom: 0; }
-.panel-shell.collapsed .dashboard-panel > :not(.panel-heading), .panel-shell.collapsed .metric-grid > article:not(:first-child), .panel-shell.collapsed > div > .dashboard-panel > :not(.panel-heading) { display: none; }
-.panel-shell.collapsed .metric-grid { display: block; }
-.panel-shell.collapsed .metric-grid article:first-child { display: flex; height: 47px; align-items: center; gap: 9px; padding-block: 0; }
-.panel-shell.collapsed .metric-grid article:first-child strong { margin-left: auto; }
-.panel-shell .panel-heading { padding-right: 54px; }
-.panel-reordering, .panel-reordering * { cursor: grabbing !important; user-select: none !important; -webkit-user-select: none !important; }
-.panel-resizing, .panel-resizing * { user-select: none !important; -webkit-user-select: none !important; }
-.panel-item-clipped { display: none !important; }
-
-@container (max-width: 620px) {
-  .metric-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-  .request-stats, .cache-stats { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-  .node-form, .mcp-form, .dataset-form { grid-template-columns: 1fr 1fr; }
-}
-
-@container (max-width: 390px) {
-  .metric-grid, .request-stats, .cache-stats { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-  .node-form, .mcp-form, .dataset-form, .profile-create { grid-template-columns: 1fr; }
-  .panel-heading p { display: none; }
-}
-.panel-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
-.panel-heading-actions { display: flex; align-items: center; gap: 8px; }
-.panel-heading-actions button { min-height: 28px; border: 1px solid var(--accent-border); border-radius: 7px; padding: 5px 9px; color: var(--accent-ink); background: var(--accent-soft); font-size: 9px; }
-.panel-heading-actions button:hover { border-color: var(--accent); color: var(--accent-hover); background: var(--surface-hover); }
-.panel-heading h2 { margin: 0 0 3px; font-size: 14px; font-weight: 630; }
-.panel-heading p { color: var(--muted); letter-spacing: 0; text-transform: none; }
-.panel-heading b { color: #81563a; font-size: 10px; font-weight: 620; }
-.runtime-chart { width: 100%; height: 190px; margin-top: 13px; overflow: visible; }
-.runtime-chart line { stroke: #e8e9e5; stroke-width: 0.42; }
-.runtime-chart polyline { fill: none; stroke: #a1653d; stroke-linecap: round; stroke-linejoin: round; stroke-width: 1.5; vector-effect: non-scaling-stroke; }
-.dashboard-panel dl { margin: 12px 0 0; }
-.dashboard-panel dl div { display: grid; grid-template-columns: 88px minmax(0, 1fr); border-top: 1px solid var(--panel-line); padding: 8px 0; }
-.dashboard-panel dt { color: var(--muted); font-size: 9px; }
-.dashboard-panel dd { overflow: hidden; margin: 0; color: var(--ink-soft); font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
-.mcp-panel { margin-top: 10px; }
-.cluster-panel { margin-top: 10px; }
-.node-form { display: grid; grid-template-columns: minmax(100px, .4fr) minmax(180px, 1fr) minmax(160px, .8fr) auto; gap: 7px; margin-top: 12px; }
-.node-form input, .node-form button { min-width: 0; border: 1px solid var(--panel-line); border-radius: 7px; padding: 7px 9px; background: var(--panel-control); font-size: 9px; }
-.node-list { display: grid; margin-top: 10px; }
-.node-list > div { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 8px; border-top: 1px solid var(--panel-line); padding: 8px 0; }
-.node-list > div > div { display: grid; min-width: 0; gap: 2px; }
-.node-list strong { font-size: 10px; }
-.node-list small { overflow: hidden; color: var(--muted); font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
-.node-list button { border: 0; color: var(--muted); background: transparent; font-size: 9px; }
-.mcp-form { display: grid; grid-template-columns: minmax(110px, .3fr) auto minmax(240px, 1fr) auto; gap: 7px; margin-top: 12px; }
-.mcp-form input, .mcp-form select { min-width: 0; border: 1px solid var(--panel-line); border-radius: 7px; padding: 7px 9px; background: var(--panel-control); font-size: 10px; }
-.mcp-form button { min-width: 64px; border: 1px solid var(--accent); border-radius: 7px; padding: 7px 11px; color: var(--on-accent); background: var(--accent); font-size: 9px; font-weight: 620; }
-.mcp-form button:hover { border-color: var(--accent-hover); background: var(--accent-hover); }
-.mcp-server-list { display: grid; gap: 4px; margin-top: 10px; }
-.mcp-server { display: grid; grid-template-columns: auto minmax(0, 1fr) auto auto; align-items: center; gap: 8px; border-top: 1px solid var(--panel-line); padding: 8px 0; }
-.mcp-server div { display: grid; min-width: 0; gap: 2px; }
-.mcp-server strong { font-size: 10px; }
-.mcp-server small { overflow: hidden; color: var(--muted); font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
-.mcp-server button { border: 0; color: var(--muted); background: transparent; font-size: 9px; }
-.panel-action { width: 100%; border: 1px solid var(--panel-line); border-radius: 7px; margin-top: 7px; padding: 7px 9px; color: var(--muted); background: var(--panel-control); font-size: 9px; }
-.panel-action:hover { border-color: var(--line-strong); color: var(--ink); background: var(--surface-hover); }
-.model-file-action { display: inline-flex; align-items: center; justify-content: center; gap: 5px; }
-.request-panel { margin-top: 10px; }
-.cache-panel { margin-top: 10px; }
-.profile-panel { margin-top: 10px; }
-.profile-create { display: grid; grid-template-columns: minmax(180px, 1fr) auto; gap: 7px; margin-top: 12px; }
-.profile-create input { min-width: 0; border: 1px solid var(--panel-line); border-radius: 7px; padding: 7px 9px; background: var(--panel-control); font-size: 10px; }
-.profile-create button, .profile-row button { border: 1px solid var(--panel-line); border-radius: 7px; padding: 6px 9px; color: var(--muted); background: var(--panel-control); font-size: 9px; }
-.profile-list { display: grid; gap: 2px; margin-top: 10px; }
-.profile-row { display: grid; grid-template-columns: minmax(0, 1fr) auto auto; align-items: center; gap: 7px; border-top: 1px solid var(--panel-line); padding: 8px 0; }
-.profile-row > div { display: grid; min-width: 0; gap: 2px; }
-.profile-row strong { font-size: 10px; }
-.profile-row small { overflow: hidden; color: var(--muted); font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
-.profile-row.drifted strong { color: #9b5b46; }
-.cache-stats { display: grid; grid-template-columns: repeat(5, 1fr); gap: 8px; margin-top: 14px; }
-.cache-stats > div { display: grid; gap: 2px; border-left: 2px solid var(--panel-line); padding-left: 9px; }
-.cache-stats span { color: var(--muted-light); font-size: 8px; }
-.cache-stats strong { color: var(--ink-soft); font-size: 12px; font-weight: 620; }
-.panel-action.danger { color: #935b4a; }
-.request-stats { display: grid; grid-template-columns: repeat(6, 1fr); gap: 8px; margin-top: 14px; }
-.request-stats > div { display: grid; border-left: 2px solid rgb(154 93 49 / 18%); padding-left: 9px; }
-.request-stats span, .request-stats small { color: var(--muted-light); font-size: 8px; }
-.request-stats strong { margin: 2px 0; font-size: 14px; font-weight: 630; }
-.model-list, .request-table { display: grid; gap: 2px; margin-top: 12px; }
-.model-row, .request-row { display: grid; min-width: 0; align-items: center; border-top: 1px solid var(--panel-line); padding: 9px 1px; }
-.model-row { grid-template-columns: 8px minmax(0, 1fr) auto; gap: 9px; }
-.model-state { width: 7px; height: 7px; border-radius: 50%; background: #c6c8c4; }
-.model-state.active { background: var(--success); box-shadow: 0 0 0 3px rgb(90 154 112 / 10%); }
-.model-state.failed { background: var(--danger); }
-.model-row div, .request-row div { display: grid; min-width: 0; gap: 2px; }
-.model-row strong, .request-row strong { overflow: hidden; color: var(--ink-soft); font-size: 9px; font-weight: 620; text-overflow: ellipsis; white-space: nowrap; }
-.model-row small, .request-row small { color: var(--muted-light); font-size: 8px; }
-.model-row em { border-radius: 999px; padding: 2px 6px; color: var(--success); background: var(--success-soft); font-size: 8px; font-style: normal; }
-.model-row em.failed { color: var(--danger); background: var(--danger-soft); }
-.model-row > button { border: 1px solid var(--panel-line); border-radius: 6px; padding: 4px 7px; color: var(--accent); background: var(--panel-control); font-size: 8px; }
-.request-row { grid-template-columns: minmax(0, 1fr) auto 74px; gap: 12px; }
-.request-row > span { color: var(--muted); font-size: 8px; }
-.request-row > b { color: #81563a; font-size: 9px; font-weight: 620; text-align: right; }
-.job-row { display: grid; grid-template-columns: minmax(0, 1fr) minmax(70px, 110px) 38px; gap: 10px; align-items: center; border-top: 1px solid var(--panel-line); padding: 9px 1px; }
-.job-row div { display: grid; min-width: 0; gap: 2px; }
-.job-row strong { overflow: hidden; color: var(--ink-soft); font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
-.job-row small { color: var(--muted-light); font-size: 8px; }
-.job-row progress { width: 100%; height: 5px; accent-color: #a1653d; }
-.job-row > b { color: var(--muted); font-size: 8px; text-align: right; }
-.job-row.completed { grid-template-columns: minmax(0, 1fr) minmax(70px, 110px) 38px 24px; }
-.job-row.completed > button { display: grid; width: 24px; height: 24px; place-content: center; border: 0; border-radius: 6px; padding: 0; color: var(--muted); background: transparent; }
-.job-row.completed > button:hover { color: var(--danger); background: var(--danger-soft); }
-.completed-jobs { border-top: 1px solid var(--panel-line); margin-top: 10px; }
-.completed-jobs > summary { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 9px 1px 5px; color: var(--muted); cursor: pointer; font-size: 9px; list-style: none; }
-.completed-jobs > summary::-webkit-details-marker { display: none; }
-.completed-jobs > summary > span { display: inline-flex; align-items: center; gap: 5px; font-weight: 600; }
-.completed-jobs > summary > span::before { content: "›"; display: inline-block; color: var(--muted-light); transition: transform 140ms ease; }
-.completed-jobs[open] > summary > span::before { transform: rotate(90deg); }
-.completed-jobs > summary b { color: var(--muted-light); font-size: 8px; }
-.completed-jobs > summary button { border: 1px solid var(--panel-line); border-radius: 6px; padding: 4px 7px; color: var(--muted); background: var(--panel-control); font-size: 8px; }
-.completed-jobs > summary button:hover { border-color: var(--line-strong); color: var(--danger); background: var(--danger-soft); }
-.completed-jobs .request-table, .completed-jobs .job-list { margin-top: 3px; }
-.runtime-log-list { display: grid; margin-top: 12px; }
-.runtime-log { display: grid; grid-template-columns: 66px minmax(0, 1fr); gap: 8px; border-top: 1px solid var(--panel-line); padding: 7px 1px; }
-.runtime-log span { color: var(--muted-light); font-size: 8px; }
-.runtime-log p { min-width: 0; overflow-wrap: anywhere; margin: 0; color: var(--ink-soft); font: 8px/1.45 ui-monospace, SFMono-Regular, Menlo, monospace; white-space: pre-wrap; }
-.runtime-log.error p { color: var(--danger); }
-.lab-grid { display: grid; grid-template-columns: minmax(280px, .9fr) minmax(340px, 1.1fr); gap: 10px; }
-.hub-panel { margin-bottom: 10px; }
-.hub-search { display: grid; grid-template-columns: auto minmax(180px, 1fr) auto; gap: 7px; margin-top: 12px; }
-.hub-search input, .hub-search select, .hub-search button, .hub-detail button { border: 1px solid var(--panel-line); border-radius: 7px; padding: 7px 9px; color: var(--ink); background: var(--panel-control); font-size: 9px; }
-.hub-results { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 4px; margin-top: 10px; }
-.hub-results > button { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 8px; border: 1px solid var(--panel-line); border-radius: 7px; padding: 8px; color: inherit; background: var(--panel-control); text-align: left; }
-.hub-results > button.active, .hub-results > button:hover { border-color: var(--accent-border); background: var(--accent-soft); }
-.hub-results div, .hub-detail > div { display: grid; min-width: 0; gap: 2px; }
-.hub-results strong, .hub-detail strong { overflow: hidden; font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
-.hub-results small, .hub-detail small, .hub-results span { color: var(--muted); font-size: 8px; }
-.hub-detail { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 10px; border-top: 1px solid var(--panel-line); margin-top: 10px; padding-top: 10px; }
-.hub-detail button { display: flex; align-items: center; gap: 5px; }
-.evaluation-grid { margin-bottom: 10px; }
-.evaluation-list, .dataset-list, .lineage-list { display: grid; gap: 3px; margin-top: 11px; }
-.evaluation-list > label { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 8px; border-top: 1px solid var(--panel-line); padding: 8px 1px; }
-.evaluation-list div, .dataset-list div > div, .lineage-list summary > div { display: grid; min-width: 0; gap: 2px; }
-.evaluation-list strong, .dataset-list strong, .lineage-list strong { overflow: hidden; font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
-.evaluation-list small, .dataset-list small, .lineage-list small, .evaluation-list > label > span { color: var(--muted); font-size: 8px; }
-.comparison-table { margin-top: 10px; overflow-x: auto; }
-.comparison-table header, .comparison-table > div { display: grid; grid-template-columns: minmax(120px, 1fr) repeat(4, minmax(90px, auto)); gap: 8px; border-top: 1px solid var(--panel-line); padding: 7px 1px; font-size: 8px; }
-.comparison-table header { color: var(--muted); }
-.comparison-table small { color: var(--accent); }
-.dataset-form { display: grid; grid-template-columns: minmax(90px, .7fr) auto minmax(150px, 1fr) auto; gap: 6px; margin-top: 11px; }
-.dataset-form input, .dataset-form select, .dataset-form button { min-width: 0; border: 1px solid var(--panel-line); border-radius: 7px; padding: 7px 8px; background: var(--panel-control); font-size: 9px; }
-.dataset-list > div { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; border-top: 1px solid var(--panel-line); padding: 8px 1px; }
-.dataset-list button { border: 0; color: var(--muted); background: transparent; }
-.lineage-panel { margin-bottom: 10px; }
-.imatrix-panel { margin-bottom: 10px; }
-.imatrix-actions { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 10px; }
-.imatrix-actions button { display: inline-flex; height: 25px; align-items: center; gap: 4px; border: 1px solid var(--panel-line); border-radius: 6px; padding: 0 7px; color: var(--muted); background: var(--panel-control); font-size: 8px; font-weight: 550; line-height: 1; }
-.imatrix-actions button:hover { border-color: var(--line-strong); color: var(--ink); background: var(--surface-hover); }
-.imatrix-list { display: grid; gap: 5px; margin-top: 9px; }
-.imatrix-list button { display: flex; align-items: center; justify-content: space-between; gap: 12px; width: 100%; padding: 8px 9px; border: 1px solid var(--panel-line); border-radius: 7px; background: var(--panel-control); color: var(--ink); text-align: left; }
-.imatrix-list button:hover { border-color: #b9a08c; }
-.imatrix-list button div { min-width: 0; display: grid; gap: 2px; }
-.imatrix-list strong, .imatrix-list small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.imatrix-list small { color: var(--muted); font-size: 8px; }
-.imatrix-list span { flex: 0 0 auto; color: var(--accent); font-size: 8px; font-weight: 650; }
-.lineage-list details { border-top: 1px solid var(--panel-line); }
-.lineage-list summary { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 8px; padding: 8px 1px; cursor: pointer; }
-.lineage-list summary > span { color: var(--muted); font-size: 8px; }
-.lineage-list dl { margin: 0 10px; }
-.lineage-list pre { max-height: 180px; overflow: auto; border-radius: 7px; padding: 9px; background: var(--surface-subtle); font: 8px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; }
-.job-builder label { display: grid; gap: 5px; margin-top: 10px; color: var(--muted); font-size: 9px; }
-.job-builder label > span { color: var(--ink-soft); font-weight: 600; }
-.job-builder label > small { color: var(--muted-light); font-size: 8px; line-height: 1.45; }
-.job-builder input:not([type="checkbox"]), .job-builder select { width: 100%; border: 1px solid var(--panel-line); border-radius: 7px; outline: 0; padding: 7px 8px; color: var(--ink); background: var(--panel-control); font-size: 9px; }
-.job-builder input:focus, .job-builder select:focus { border-color: #b9a08c; box-shadow: 0 0 0 2px rgb(161 101 61 / 8%); }
-.job-submit { display: flex; justify-content: flex-end; border-top: 1px solid var(--panel-line); margin-top: 16px; padding-top: 12px; }
-.job-run {
-  display: inline-flex;
-  min-width: 86px;
-  height: 32px;
-  align-items: center;
-  justify-content: center;
-  gap: 7px;
-  border: 1px solid var(--accent);
-  border-radius: 9px;
-  padding: 0 15px;
-  color: var(--on-accent);
-  background: var(--accent);
-  font-size: 10px;
-  font-weight: 650;
-  box-shadow: 0 5px 14px rgb(122 72 36 / 16%);
-}
-.job-run:hover { border-color: var(--accent-hover); background: var(--accent-hover); transform: translateY(-1px); box-shadow: 0 7px 18px rgb(122 72 36 / 20%); }
-.job-run:active { transform: translateY(0); box-shadow: none; }
-.job-list { display: grid; max-height: 500px; margin-top: 10px; overflow-y: auto; }
-.job-list > button { display: grid; grid-template-columns: 8px minmax(0, 1fr) 38px; gap: 9px; align-items: center; border: 0; border-top: 1px solid var(--panel-line); padding: 9px 4px; color: inherit; background: transparent; text-align: left; }
-.job-list > button:hover, .job-list > button.active { background: var(--surface-active); }
-.job-list div { display: grid; min-width: 0; gap: 2px; }
-.job-list strong { overflow: hidden; font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
-.job-list small { color: var(--muted-light); font-size: 8px; }
-.job-list b { color: var(--muted); font-size: 8px; text-align: right; }
-.job-status { width: 7px; height: 7px; border-radius: 50%; background: #bfc1bd; }
-.job-status.running { background: #b9824d; box-shadow: 0 0 0 3px rgb(185 130 77 / 10%); }
-.job-status.succeeded { background: var(--success); }
-.job-status.failed, .job-status.interrupted { background: var(--danger); }
-.job-status.cancelling, .job-status.cancelled { background: #858a87; }
-.job-detail { margin-top: 10px; }
-.job-detail > progress { width: 100%; height: 6px; margin: 15px 0 8px; accent-color: #a1653d; }
-.job-result-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; margin: 8px 0; }
-.job-result-grid > div { display: grid; border-left: 2px solid #dfc5b1; padding-left: 9px; }
-.job-result-grid span { color: var(--muted-light); font-size: 8px; }
-.job-result-grid strong { margin-top: 2px; font-size: 11px; }
-.job-detail > pre { max-height: 240px; overflow: auto; border-radius: 7px; padding: 10px; color: var(--ink-soft); background: var(--surface-inset); font: 8px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; }
-.job-error { overflow-wrap: anywhere; border-radius: 7px; margin-top: 10px; padding: 9px; color: var(--danger); background: var(--danger-soft); font-size: 9px; white-space: pre-wrap; }
-.job-actions { display: flex; gap: 7px; flex-wrap: wrap; }
-.job-actions .secondary { border: 1px solid var(--panel-line); border-radius: 7px; padding: 6px 9px; color: var(--muted); background: var(--panel-control); font-size: 9px; }
-.job-actions .secondary:hover { border-color: var(--line-strong); color: var(--ink); background: var(--surface-hover); }
-.job-actions .danger { color: var(--danger); }
-.job-log { max-height: 320px; margin-top: 12px; overflow: auto; border: 1px solid var(--panel-line); border-radius: 8px; background: var(--panel-control); }
-.job-log header { position: sticky; top: 0; padding: 7px 9px; color: var(--muted); background: var(--surface-subtle); font-size: 8px; text-transform: uppercase; }
-.job-log > div { display: grid; grid-template-columns: 70px minmax(0, 1fr); gap: 8px; border-top: 1px solid var(--line-soft); padding: 6px 9px; }
-.job-log time { color: var(--muted-light); font-size: 8px; }
-.job-log code { overflow-wrap: anywhere; color: var(--ink-soft); font: 8px/1.45 ui-monospace, SFMono-Regular, Menlo, monospace; }
-.job-log .error code { color: var(--danger); }
-
-
-.dialog-backdrop { position: fixed; inset: 0; z-index: 20; background: rgb(21 23 23 / 34%); backdrop-filter: blur(3px); }
-.studio-dialog header { display: flex; align-items: flex-start; justify-content: space-between; padding: 18px 18px 12px; }
-.studio-dialog h2 { margin: 3px 0 0; font-size: 17px; font-weight: 650; letter-spacing: -0.015em; }
-.studio-dialog header > button { width: 28px; height: 28px; border: 0; padding: 0; color: #777a79; background: transparent; font-size: 20px; }
-.studio-dialog label { display: grid; gap: 5px; margin: 9px 0; color: var(--muted); font-size: 9px; }
-.studio-dialog label > span { display: flex; justify-content: space-between; }
-.studio-dialog input { width: 100%; border: 1px solid var(--line); border-radius: 7px; outline: 0; padding: 7px 8px; color: var(--ink); background: var(--surface-control); }
-.studio-dialog input:focus { border-color: #b88b6b; box-shadow: 0 0 0 2px rgb(154 93 49 / 8%); }
-.segmented { grid-template-columns: repeat(3, 1fr); }
-.segmented button { font-size: 9px; }
-.segmented button[aria-pressed="true"] { border-color: var(--accent-border); color: var(--accent-ink); background: var(--accent-soft); }
-.saved-presets { display: grid; gap: 7px; border-top: 1px solid var(--line-soft); margin-top: 11px; padding-top: 11px; }
-.saved-presets label { margin: 0; }
-.saved-presets > small { color: var(--muted-light); font-size: 8px; line-height: 1.45; }
-.preset-save-row { display: grid; grid-template-columns: minmax(0, 1fr) auto 30px; gap: 5px; }
-.preset-save-row input { min-width: 0; }
-.preset-save-row button { padding-inline: 10px; white-space: nowrap; }
-.preset-save-row .preset-delete { display: grid; width: 30px; place-items: center; padding: 0; color: #8b5a55; }
-.preset-status { margin: 0; color: #568069; font-size: 8px; }
-.preset-status.error { color: var(--danger); }
-.portable-actions { display: flex; gap: 6px; }
-.portable-actions button, .portable-actions label { display: grid; place-items: center; border: 1px solid var(--line); border-radius: 7px; margin: 0; padding: 6px 10px; color: var(--muted); background: var(--surface-subtle); font-size: 9px; cursor: pointer; }
-.portable-actions input { display: none; }
-.studio-dialog footer { display: flex; justify-content: flex-end; gap: 7px; border-top: 1px solid var(--line); padding: 11px 17px; background: var(--surface-overlay); }
-
-.dialog-backdrop { display: grid; place-items: center; z-index: 30; padding: 20px; }
-.studio-dialog { display: grid; width: min(500px, 100%); max-height: 90vh; overflow-y: auto; border: 1px solid var(--line); border-radius: 13px; color: var(--ink); background: var(--canvas); box-shadow: var(--shadow-md); }
-.studio-dialog header { padding-bottom: 8px; }
-.studio-dialog header p { margin: 4px 0 0; color: var(--muted); font-size: 9px; }
-.studio-dialog > .segmented, .studio-dialog > label, .dialog-status { margin-inline: 18px; }
-.studio-dialog > .segmented { border-radius: 8px; padding: 3px; background: var(--surface-subtle); }
-.dialog-status { display: flex; align-items: center; gap: 7px; border: 1px solid var(--line); border-radius: 8px; margin-block: 10px; padding: 8px 9px; color: var(--muted); background: var(--surface); font-size: 9px; }
-.dialog-status span { width: 7px; height: 7px; flex: 0 0 auto; border-radius: 50%; }
-.dialog-status span.online { background: var(--success); }
-.dialog-status span.offline { background: var(--danger); }
-.model-browser-dialog { width: min(620px, 100%); grid-template-rows: auto auto minmax(220px, 52vh) auto; overflow: hidden; }
-.model-browser-location { display: grid; grid-template-columns: auto minmax(0, 1fr) auto auto; align-items: center; gap: 7px; border-block: 1px solid var(--line-soft); padding: 9px 18px; color: var(--muted); background: var(--surface-overlay); font-size: 9px; }
-.model-browser-location input { min-width: 0; height: 30px; border-color: var(--line-soft); border-radius: 7px; padding-inline: 10px; color: var(--ink); background: var(--surface); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 9px; }
-.model-browser-location button { min-height: 30px; padding: 6px 10px; }
-.model-browser-location span { color: var(--accent-ink); }
-.model-browser-list { min-height: 0; overflow-y: auto; padding: 7px 10px; }
-.model-browser-list > button { display: grid; width: 100%; grid-template-columns: 18px minmax(0, 1fr) auto; align-items: center; gap: 8px; border: 0; padding: 9px 10px; color: var(--ink-soft); background: transparent; text-align: left; }
-.model-browser-list > button:hover { border-color: transparent; background: var(--surface-subtle); }
-.model-browser-list > button span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.model-browser-list > button b { color: var(--muted); font-size: 8px; font-weight: 600; }
-.model-browser-list > p { margin: 28px 12px; color: var(--muted); text-align: center; font-size: 9px; }
-
-.role-dialog-backdrop { background: rgb(15 17 17 / 42%); backdrop-filter: blur(5px); }
-.role-dialog {
-  display: grid;
-  width: min(720px, 100%);
-  max-height: min(860px, 92vh);
-  grid-template-rows: auto minmax(0, 1fr) auto;
-  overflow: hidden;
-  border: 1px solid var(--line);
-  border-radius: 14px;
-  color: var(--ink);
-  background: var(--canvas);
-  box-shadow: 0 24px 70px rgb(8 10 10 / 30%);
-}
-.role-dialog header { display: flex; align-items: flex-start; justify-content: space-between; border-bottom: 1px solid var(--line-soft); padding: 17px 19px 14px; }
-.role-dialog header p { margin: 0; color: var(--accent-ink); font-size: 8px; font-weight: 700; letter-spacing: 0.1em; text-transform: uppercase; }
-.role-dialog h2 { margin: 3px 0 0; font-size: 17px; font-weight: 650; letter-spacing: -0.015em; }
-.role-dialog header > button { width: 28px; height: 28px; border: 0; padding: 0; color: var(--muted); background: transparent; font-size: 20px; }
-.role-dialog header > button:hover { color: var(--ink); }
-.role-dialog-scroll { min-height: 0; overflow-y: auto; padding: 0 19px 18px; }
-.role-dialog-scroll section { border-top: 1px solid var(--line-soft); padding: 15px 0; }
-.role-dialog-scroll section:first-child { border-top: 0; }
-.role-dialog-scroll h3 { margin: 0 0 11px; color: var(--muted); font-size: 8px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; }
-.role-dialog label { display: grid; min-width: 0; gap: 5px; margin: 0; color: var(--muted); font-size: 9px; }
-.role-dialog input:not([type="checkbox"]), .role-dialog textarea, .role-dialog select {
-  width: 100%;
-  min-width: 0;
-  border: 1px solid var(--line);
-  border-radius: 7px;
-  outline: 0;
-  padding: 8px 9px;
-  color: var(--ink);
-  background: var(--surface-control);
-  font: inherit;
-}
-.role-dialog input:not([type="checkbox"]):focus, .role-dialog textarea:focus, .role-dialog select:focus { border-color: #b88b6b; box-shadow: 0 0 0 2px rgb(154 93 49 / 8%); }
-.role-dialog textarea { resize: vertical; line-height: 1.5; }
-.role-identity-grid { display: grid; grid-template-columns: 180px minmax(0, 1fr); gap: 12px; }
-.role-icon-field > div { display: grid; grid-template-columns: 36px minmax(0, 1fr); gap: 7px; }
-.role-icon-field output { display: grid; width: 36px; height: 34px; place-items: center; border: 1px solid var(--line); border-radius: 8px; overflow: hidden; color: var(--accent-ink); background: var(--accent-soft); font-size: 11px; font-weight: 700; }
-.role-form-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 11px 12px; }
-.role-section-heading { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin-bottom: 11px; }
-.role-section-heading h3 { margin: 0; }
-.role-dialog .role-inheritance-toggle { display: flex; align-items: center; gap: 7px; color: var(--ink-soft); white-space: nowrap; }
-.role-inherited-fields { transition: opacity 120ms ease; }
-.role-checks { display: flex; flex-wrap: wrap; gap: 15px; margin-top: 13px; }
-.role-checks label { display: flex; align-items: center; gap: 7px; color: var(--ink-soft); }
-.role-checks input { accent-color: var(--accent); }
-.role-dialog footer { display: flex; justify-content: flex-end; gap: 7px; border-top: 1px solid var(--line); padding: 11px 18px; background: var(--surface-overlay); }
-.role-dialog footer button { border: 1px solid var(--line); border-radius: 7px; padding: 7px 12px; color: var(--ink-soft); background: var(--surface); }
-.role-dialog footer button:hover { border-color: var(--line-strong); background: var(--surface-subtle); }
-.role-dialog footer .primary { border-color: var(--accent); color: #fff; background: var(--accent); }
-.role-dialog footer .primary:disabled { opacity: 0.45; }
-
-@media (max-width: 1400px) {
-  .theme-switcher button { padding-inline: 6px; }
-  .theme-switcher button span { display: none; }
-}
-
-@media (max-width: 1160px) {
-  .capabilities { display: none; }
-  .metric-grid { grid-template-columns: repeat(3, 1fr); }
-  .request-stats { grid-template-columns: repeat(3, 1fr); }
-}
-
-@media (max-width: 860px) {
-  .app-shell { grid-template-columns: 210px minmax(0, 1fr); }
-  .quick-metrics span:nth-child(2) { display: none; }
-  .dashboard-grid, .dashboard-lower-grid, .lab-grid { grid-template-columns: 1fr; }
-  .dataset-form { grid-template-columns: 1fr 1fr; }
-  .node-form { grid-template-columns: 1fr 1fr; }
-  .request-stats { grid-template-columns: repeat(3, 1fr); }
-  .panel-deck { grid-template-columns: 1fr; }
-  .panel-shell { grid-column: 1; }
-  .panel-deck .panel-shell { transform: none; }
-  .panel-deck .panel-drag { display: none; }
-}
-
-@media (max-width: 680px) {
-  body { overflow: hidden; }
-  .app-shell { display: block; height: 100vh; height: 100dvh; overflow: hidden; }
-  .sidebar {
-    position: fixed;
-    inset: 0 auto 0 0;
-    z-index: 31;
-    width: min(286px, 86vw);
-    border-right: 1px solid #303233;
-    box-shadow: 18px 0 48px rgb(0 0 0 / 22%);
-    transform: translateX(-104%);
-    transition: transform 180ms ease;
-  }
-  .sidebar.open { transform: translateX(0); }
-  .mobile-scrim {
-    position: fixed;
-    inset: 0;
-    z-index: 30;
-    display: block;
-    border: 0;
-    padding: 0;
-    pointer-events: none;
-    opacity: 0;
-    background: rgb(12 14 14 / 38%);
-    backdrop-filter: blur(2px);
-    transition: opacity 180ms ease;
-  }
-  .mobile-scrim.open { pointer-events: auto; opacity: 1; }
-  .workspace { width: 100%; height: 100vh; height: 100dvh; grid-template-rows: 52px minmax(0, 1fr); }
-  .topbar { gap: 8px; padding: 0 10px; }
-  .sidebar-toggle { display: grid; }
-  .topbar-model span { max-width: 38vw; }
-  .quick-metrics { display: none; }
-  .topbar-actions { gap: 4px; }
-  .message-list { padding: 23px 13px 17px; }
-  .message { grid-template-columns: 28px minmax(0, 1fr); gap: 8px; margin-bottom: 19px; }
-  .message-user { grid-template-columns: minmax(0, 1fr) 28px; }
-  .message-avatar { width: 27px; height: 27px; }
-  .message-user .message-body { width: fit-content; max-width: min(100%, 560px); }
-  .message-actions { opacity: 1; }
-  .composer-region { padding: 0 10px 8px; }
-  .composer-hint { display: none; }
-  .composer-toolbar { flex-wrap: wrap; }
-  .composer-toolbar .send-button { margin-left: auto; }
-  .prompt-grid { grid-template-columns: 1fr; }
-  .metric-grid { grid-template-columns: 1fr 1fr; }
-  .dashboard-view, .lab-view { padding: 23px 13px 38px; }
-  .request-stats { grid-template-columns: 1fr 1fr; }
-  .dialog-backdrop { padding: 10px; }
-  .role-dialog { max-height: calc(100dvh - 20px); }
-  .role-identity-grid, .role-form-grid { grid-template-columns: 1fr; }
-}
-
-@media (max-width: 420px) {
-  .topbar-actions > button { width: 29px; height: 29px; }
-  .topbar-model small { display: none; }
-  .rich-text { font-size: 12px; }
-  .metric-grid { grid-template-columns: 1fr; }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  *, *::before, *::after { scroll-behavior: auto !important; transition-duration: 0.01ms !important; animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; }
-}
-
-/* oMLX-inspired macOS grouped interface. The legacy rules above remain the
-   compact fallback; this layer defines the current Studio presentation. */
-:root {
-  font-size: 14px;
-  --ink: #1d1d1f;
-  --ink-strong: #111113;
-  --ink-soft: #3f3f44;
-  --muted: #6e6e73;
-  --muted-light: #929297;
-  --line: rgb(60 60 67 / 16%);
-  --line-strong: rgb(60 60 67 / 25%);
-  --line-soft: rgb(60 60 67 / 9%);
-  --canvas: #fbfbfc;
-  --surface: #ffffff;
-  --surface-control: #ffffff;
-  --surface-subtle: #f2f2f4;
-  --surface-hover: #e9e9ec;
-  --surface-active: #e5e5e9;
-  --surface-inset: #f0f0f2;
-  --surface-overlay: rgb(251 251 252 / 84%);
-  --surface-user: #f0f0f3;
-  --panel-surface: #f5f5f7;
-  --panel-control: #ffffff;
-  --panel-line: rgb(60 60 67 / 12%);
-  --panel-overlap-line: rgb(60 60 67 / 16%);
-  --accent: #087cff;
-  --accent-hover: #0068df;
-  --accent-soft: rgb(8 124 255 / 11%);
-  --accent-border: rgb(8 124 255 / 28%);
-  --accent-ink: #0067d8;
-  --on-accent: #ffffff;
-  --sidebar: rgb(244 244 246 / 92%);
-  --sidebar-surface: rgb(255 255 255 / 72%);
-  --sidebar-hover: rgb(60 60 67 / 8%);
-  --sidebar-line: rgb(60 60 67 / 13%);
-  --success: #28a745;
-  --success-soft: rgb(40 167 69 / 12%);
-  --danger: #ff3b30;
-  --danger-soft: rgb(255 59 48 / 10%);
-  --shadow-sm: 0 1px 2px rgb(0 0 0 / 3%), 0 6px 18px rgb(0 0 0 / 4%);
-  --shadow-md: 0 28px 80px rgb(0 0 0 / 22%);
-}
-
-:root[data-theme="dark"] {
-  --ink: #f2f2f4;
-  --ink-strong: #ffffff;
-  --ink-soft: #d0d0d4;
-  --muted: #a0a0a7;
-  --muted-light: #73737a;
-  --line: rgb(235 235 245 / 16%);
-  --line-strong: rgb(235 235 245 / 25%);
-  --line-soft: rgb(235 235 245 / 9%);
-  --canvas: #1c1c1e;
-  --surface: #28282a;
-  --surface-control: #303033;
-  --surface-subtle: #2c2c2e;
-  --surface-hover: #38383b;
-  --surface-active: #3a3a3c;
-  --surface-inset: #18181a;
-  --surface-overlay: rgb(28 28 30 / 84%);
-  --surface-user: #303033;
-  --panel-surface: #29292b;
-  --panel-control: #333336;
-  --panel-line: rgb(235 235 245 / 11%);
-  --panel-overlap-line: rgb(235 235 245 / 16%);
-  --accent: #0a84ff;
-  --accent-hover: #409cff;
-  --accent-soft: rgb(10 132 255 / 18%);
-  --accent-border: rgb(10 132 255 / 40%);
-  --accent-ink: #65adff;
-  --on-accent: #ffffff;
-  --sidebar: rgb(31 31 33 / 95%);
-  --sidebar-surface: rgb(52 52 55 / 72%);
-  --sidebar-hover: rgb(235 235 245 / 10%);
-  --sidebar-line: rgb(235 235 245 / 13%);
-  --success: #30d158;
-  --success-soft: rgb(48 209 88 / 14%);
-  --danger: #ff453a;
-  --danger-soft: rgb(255 69 58 / 14%);
-  --shadow-sm: 0 1px 0 rgb(255 255 255 / 3%), 0 10px 28px rgb(0 0 0 / 16%);
-  --shadow-md: 0 30px 90px rgb(0 0 0 / 48%);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root[data-theme="system"] {
-    --ink: #f2f2f4;
-    --ink-strong: #ffffff;
-    --ink-soft: #d0d0d4;
-    --muted: #a0a0a7;
-    --muted-light: #73737a;
-    --line: rgb(235 235 245 / 16%);
-    --line-strong: rgb(235 235 245 / 25%);
-    --line-soft: rgb(235 235 245 / 9%);
-    --canvas: #1c1c1e;
-    --surface: #28282a;
-    --surface-control: #303033;
-    --surface-subtle: #2c2c2e;
-    --surface-hover: #38383b;
-    --surface-active: #3a3a3c;
-    --surface-inset: #18181a;
-    --surface-overlay: rgb(28 28 30 / 84%);
-    --surface-user: #303033;
-    --panel-surface: #29292b;
-    --panel-control: #333336;
-    --panel-line: rgb(235 235 245 / 11%);
-    --panel-overlap-line: rgb(235 235 245 / 16%);
-    --accent: #0a84ff;
-    --accent-hover: #409cff;
-    --accent-soft: rgb(10 132 255 / 18%);
-    --accent-border: rgb(10 132 255 / 40%);
-    --accent-ink: #65adff;
-    --on-accent: #ffffff;
-    --sidebar: rgb(31 31 33 / 95%);
-    --sidebar-surface: rgb(52 52 55 / 72%);
-    --sidebar-hover: rgb(235 235 245 / 10%);
-    --sidebar-line: rgb(235 235 245 / 13%);
-    --success: #30d158;
-    --success-soft: rgb(48 209 88 / 14%);
-    --danger: #ff453a;
-    --danger-soft: rgb(255 69 58 / 14%);
-  }
-}
-
-button:focus-visible, input:focus-visible, textarea:focus-visible,
-select:focus-visible, summary:focus-visible {
-  outline-color: rgb(10 132 255 / 42%);
-}
-::selection { background: #0a84ff; }
-
-.app-shell { grid-template-columns: 264px minmax(0, 1fr); }
-.sidebar {
-  border-right-color: var(--sidebar-line);
-  padding: 16px 12px 12px;
-  color: var(--ink);
-  background: var(--sidebar);
-  backdrop-filter: blur(28px) saturate(1.25);
-}
-.brand { gap: 11px; padding: 2px 9px 16px; }
-.brand img { width: 36px; height: 36px; border-radius: 10px; box-shadow: var(--shadow-sm); }
-.brand div { display: grid; gap: 0; }
-.brand strong { color: var(--ink-strong); font-size: 17px; font-weight: 700; }
-.brand span { color: var(--muted); font-size: 10px; letter-spacing: 0.04em; }
-.sidebar-group-label,
-.assistant-heading,
-.history-heading {
-  padding: 11px 9px 6px;
-  color: var(--muted-light);
-  font-size: 10px;
-  font-weight: 650;
-  letter-spacing: 0;
-  text-transform: none;
-}
-.sidebar-divider { background: var(--sidebar-line); }
-.primary-nav { gap: 4px; margin: 0 0 10px; }
-.primary-nav button,
-.context-nav button {
-  min-height: 38px;
-  gap: 10px;
-  border-radius: 9px;
-  padding: 8px 10px;
-  color: var(--ink-soft);
-  font-size: 13px;
-  font-weight: 540;
-}
-.primary-nav button:hover,
-.context-nav button:hover { color: var(--ink); background: var(--sidebar-hover); }
-.primary-nav button.active,
-.context-nav button.active {
-  color: #fff;
-  background: var(--accent);
-  box-shadow: 0 5px 16px rgb(10 132 255 / 20%);
-}
-.primary-nav button.active .ui-icon { color: currentColor; }
-.primary-nav button span {
-  min-width: 24px;
-  border: 0;
-  color: currentColor;
-  background: rgb(127 127 127 / 16%);
-  font-size: 10px;
-}
-.assistant-heading small { color: var(--muted-light); font-size: 9px; }
-.assistant-list { max-height: min(210px, 27vh); gap: 3px; }
-.assistant-row { min-height: 46px; border-radius: 9px; }
-.assistant-row:hover, .assistant-row.active { background: var(--sidebar-hover); }
-.assistant-main { grid-template-columns: 32px minmax(0, 1fr); gap: 9px; padding: 7px 9px; color: var(--ink-soft); }
-.assistant-row:hover .assistant-main, .assistant-row.active .assistant-main { color: var(--ink); }
-.assistant-main > span {
-  width: 31px;
-  height: 31px;
-  border-color: var(--sidebar-line);
-  border-radius: 9px;
-  color: var(--accent-ink);
-  background: var(--sidebar-surface);
-  font-size: 12px;
-}
-.assistant-list strong { font-size: 12px; }
-.assistant-list small { color: var(--muted); font-size: 10px; }
-.new-session {
-  min-height: 38px;
-  border-color: var(--accent-border);
-  border-radius: 9px;
-  color: var(--accent-ink);
-  background: var(--accent-soft);
-  font-size: 12px;
-}
-.new-session:hover { border-color: var(--accent); color: var(--accent-hover); background: var(--accent-soft); }
-.context-sidebar-heading { border-bottom-color: var(--sidebar-line); padding: 12px 9px 16px; }
-.context-sidebar-heading strong { color: var(--ink); font-size: 15px; }
-.context-sidebar-heading small { color: var(--muted); font-size: 10px; }
-.context-nav { gap: 4px; padding-top: 12px; }
-.session-create { border-block-color: var(--sidebar-line); }
-.session-create summary { color: var(--muted); font-size: 10px; }
-.session-create label { color: var(--muted); font-size: 10px; }
-.session-create select, .open-local-model {
-  min-height: 36px;
-  border-color: var(--sidebar-line);
-  color: var(--ink-soft);
-  background: var(--sidebar-surface);
-  font-size: 11px;
-}
-.mode-picker { background: rgb(127 127 127 / 10%); }
-.mode-picker button { min-height: 28px; color: var(--muted); font-size: 10px; }
-.mode-picker button[aria-pressed="true"] { color: var(--ink); background: var(--surface); box-shadow: var(--shadow-sm); }
-.session-row { min-height: 46px; border-radius: 9px; }
-.session-row:hover, .session-row.active { background: var(--sidebar-hover); }
-.session-row.active { box-shadow: inset 3px 0 var(--accent); }
-.session-main { padding: 8px 10px; color: var(--ink-soft); font-size: 12px; }
-.session-main small, .empty-note { color: var(--muted); font-size: 10px; }
-.session-actions button, .assistant-edit, .history-heading button { color: var(--muted); }
-.session-actions button:hover, .assistant-edit:hover, .history-heading button:hover { color: var(--ink); background: var(--sidebar-hover); }
-.sidebar-runtime-card {
-  display: grid;
-  width: 100%;
-  grid-template-columns: 9px minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 9px;
-  border: 1px solid var(--sidebar-line);
-  border-radius: 12px;
-  margin-top: 10px;
-  padding: 10px;
-  color: var(--ink-soft);
-  background: var(--sidebar-surface);
-  text-align: left;
-}
-.sidebar-runtime-card:hover { border-color: var(--line-strong); background: var(--surface-hover); }
-.sidebar-runtime-card > span:nth-child(2) { display: grid; min-width: 0; gap: 2px; }
-.sidebar-runtime-card strong, .sidebar-runtime-card small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.sidebar-runtime-card strong { font-size: 11px; font-weight: 620; }
-.sidebar-runtime-card small { color: var(--muted); font-size: 9px; }
-.runtime-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--muted-light); }
-.runtime-dot.ready { background: var(--success); box-shadow: 0 0 0 4px var(--success-soft); }
-.runtime-dot.busy { background: var(--accent); box-shadow: 0 0 0 4px var(--accent-soft); }
-
-.workspace { grid-template-rows: 62px minmax(0, 1fr); background: var(--canvas); }
-.topbar {
-  border-bottom-color: var(--line-soft);
-  padding: 0 22px;
-  background: var(--surface-overlay);
-  backdrop-filter: blur(26px) saturate(1.2);
-}
-.topbar-model span { max-width: min(30vw, 430px); font-size: 13px; font-weight: 640; }
-.topbar-model small { font-size: 10px; }
-.topbar-actions > button, .sidebar-toggle { width: 34px; height: 34px; border-radius: 9px; }
-.theme-switcher { border-color: var(--line-soft); border-radius: 10px; background: var(--surface-subtle); }
-.theme-switcher button { min-height: 27px; padding: 4px 8px; font-size: 9px; }
-.theme-switcher button[aria-pressed="true"] { color: var(--accent-ink); }
-.capabilities span { border-color: var(--line-soft); padding: 4px 8px; font-size: 9px; }
-.quick-metrics { gap: 14px; border-color: var(--line-soft); }
-.quick-metrics span { font-size: 8px; }
-.quick-metrics b { font-size: 11px; }
-
-.message-list { width: min(920px, 100%); padding: 38px 34px 26px; }
-.welcome { max-width: 610px; margin-top: 13vh; }
-.welcome img { width: 58px; height: 58px; border-radius: 15px; }
-.welcome h1, .welcome h2 { font-size: 30px; font-weight: 700; letter-spacing: -0.035em; }
-.welcome p { max-width: 510px; margin-top: 11px; font-size: 14px; line-height: 1.55; }
-.open-model-primary { min-height: 42px; border-radius: 11px; padding: 9px 16px; font-size: 13px; }
-.prompt-grid { gap: 10px; margin-top: 24px; }
-.prompt-grid button { border-radius: 12px; padding: 14px 15px; font-size: 13px; }
-.message { grid-template-columns: 36px minmax(0, 1fr); gap: 13px; margin-bottom: 28px; }
-.message-user { grid-template-columns: minmax(0, 1fr) 36px; }
-.message-avatar { width: 34px; height: 34px; border-radius: 10px; font-size: 10px; }
-.message-avatar img { width: 25px; height: 25px; }
-.message-user .message-body { max-width: min(680px, 92%); }
-.message-user .message-content { border-color: transparent; border-radius: 18px 5px 18px 18px; padding: 11px 14px; }
-.message-meta { gap: 8px; margin-bottom: 7px; }
-.message-meta strong { font-size: 12px; }
-.message-meta span { font-size: 10px; }
-.rich-text { color: var(--ink); font-size: 14px; line-height: 1.68; }
-.rich-text pre { border-radius: 12px; padding: 14px; }
-.message-actions button { border-radius: 7px; padding: 4px 7px; font-size: 10px; }
-.response-metrics { font-size: 10px; }
-.reasoning { border-color: var(--line-soft); border-radius: 11px; background: var(--surface-subtle); }
-.composer-region { width: min(920px, 100%); padding: 0 22px 14px; }
-.composer {
-  border-color: var(--line-strong);
-  border-radius: 17px;
-  background: var(--surface);
-  box-shadow: 0 12px 36px rgb(0 0 0 / 8%);
-}
-.composer:focus-within { border-color: var(--accent-border); box-shadow: 0 0 0 3px var(--accent-soft), 0 16px 42px rgb(0 0 0 / 10%); }
-.composer textarea { min-height: 50px; padding: 14px 15px 6px; font-size: 14px; }
-.composer-toolbar { min-height: 44px; padding: 5px 8px 8px; }
-.composer-toolbar > button, .composer-toolbar select { height: 31px; border-radius: 9px; font-size: 10px; }
-.composer-toolbar .send-button { width: 32px; }
-.voice-button span { background: var(--accent); box-shadow: 0 0 calc(4px + var(--voice-level) * 9px) rgb(10 132 255 / 46%); }
-.composer-hint { font-size: 9px; }
-
-.dashboard-view, .lab-view { padding: 38px clamp(28px, 4vw, 68px) 60px; }
-.dashboard-view > *, .lab-view > * { width: min(1280px, 100%); }
-.page-heading { align-items: center; margin-bottom: 22px; }
-.page-heading p { color: var(--muted); font-size: 11px; letter-spacing: 0.02em; text-transform: none; }
-.page-heading h1 { margin: 2px 0 0; font-size: 34px; font-weight: 720; letter-spacing: -0.04em; }
-.page-heading > button { width: 36px; height: 36px; border-radius: 10px; }
-.runtime-hero {
-  display: grid;
-  grid-template-columns: 58px minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 17px;
-  border-radius: 16px;
-  margin-bottom: 18px;
-  padding: 18px 20px;
-  background: var(--panel-surface);
-}
-.runtime-hero > img { width: 54px; height: 54px; border-radius: 14px; background: var(--surface); box-shadow: var(--shadow-sm); }
-.runtime-hero-copy { min-width: 0; }
-.runtime-hero-copy > div { display: flex; align-items: center; gap: 10px; }
-.runtime-hero h2 { overflow: hidden; margin: 0; color: var(--ink-strong); font-size: 19px; font-weight: 680; text-overflow: ellipsis; white-space: nowrap; }
-.runtime-hero p { margin: 4px 0 0; color: var(--muted); font-size: 12px; }
-.runtime-status-pill { display: inline-flex; align-items: center; gap: 5px; border-radius: 999px; padding: 4px 8px; color: var(--muted); background: var(--surface-hover); font-size: 10px; font-weight: 650; }
-.runtime-status-pill i { width: 7px; height: 7px; border-radius: 50%; background: var(--muted-light); }
-.runtime-status-pill.running { color: var(--success); background: var(--success-soft); }
-.runtime-status-pill.running i { background: var(--success); }
-.runtime-hero-actions { display: flex; gap: 8px; }
-.runtime-hero-actions button {
-  display: inline-flex;
-  min-height: 36px;
-  align-items: center;
-  gap: 7px;
-  border: 1px solid var(--line);
-  border-radius: 10px;
-  padding: 7px 12px;
-  color: var(--ink-soft);
-  background: var(--surface);
-  font-size: 11px;
-  font-weight: 590;
-}
-.runtime-hero-actions button:hover { border-color: var(--line-strong); background: var(--surface-hover); }
-.runtime-hero-actions button.primary { border-color: var(--accent); color: #fff; background: var(--accent); }
-.runtime-hero-actions button.primary:hover { background: var(--accent-hover); }
-.metric-grid { gap: 12px; margin-bottom: 13px; }
-.metric-grid article, .dashboard-panel { border-radius: 14px; background: var(--panel-surface); }
-.metric-grid article { min-height: 118px; align-content: center; padding: 18px; text-align: center; }
-.metric-grid span { font-size: 10px; font-weight: 650; letter-spacing: 0.045em; text-transform: uppercase; }
-.metric-grid strong { margin: 7px 0 4px; font-size: 26px; font-weight: 680; }
-.metric-grid small { font-size: 10px; }
-.dashboard-panel { padding: 19px; }
-.panel-deck { gap: 13px; }
-.panel-heading { gap: 14px; }
-.panel-heading h2 { font-size: 16px; font-weight: 660; }
-.panel-heading p { color: var(--muted); font-size: 10px; line-height: 1.45; }
-.panel-heading b, .request-row > b { color: var(--accent-ink); font-size: 11px; }
-.runtime-chart { height: 225px; margin-top: 18px; }
-.runtime-chart line { stroke: var(--line-soft); }
-.runtime-chart polyline { stroke: var(--accent); stroke-width: 2; }
-.dashboard-panel dl div { grid-template-columns: 105px minmax(0, 1fr); padding: 10px 0; }
-.dashboard-panel dt, .dashboard-panel dd { font-size: 11px; }
-.panel-action { min-height: 36px; border-radius: 9px; padding: 8px 10px; font-size: 11px; }
-.request-stats, .cache-stats { gap: 12px; margin-top: 17px; }
-.request-stats > div, .cache-stats > div { border-left-color: var(--accent-border); padding-left: 11px; }
-.request-stats span, .request-stats small, .cache-stats span { font-size: 10px; }
-.request-stats strong { font-size: 17px; }
-.cache-stats strong { font-size: 14px; }
-.model-load-policy {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-  gap: 8px;
-  margin-top: 15px;
-}
-.model-load-policy > label {
-  display: flex;
-  min-width: 0;
-  min-height: 52px;
-  align-items: center;
-  gap: 10px;
-  border: 1px solid var(--panel-line);
-  border-radius: 11px;
-  padding: 9px 11px;
-  background: var(--panel-control);
-}
-.model-load-policy > label > span { display: grid; min-width: 0; gap: 2px; }
-.model-load-policy strong { font-size: 11px; font-weight: 630; }
-.model-load-policy small { color: var(--muted); font-size: 9px; }
-.model-load-policy input { accent-color: var(--accent); }
-.model-load-policy select { min-width: 92px; margin-left: auto; border: 1px solid var(--line); border-radius: 8px; padding: 6px 8px; color: var(--ink); background: var(--surface); font-size: 10px; }
-.model-list, .request-table { margin-top: 15px; }
-.model-row, .request-row { padding: 12px 2px; }
-.model-row strong, .request-row strong { font-size: 11px; }
-.model-row small, .request-row small, .request-row > span { font-size: 9px; }
-.model-row > button, .model-row em { border-radius: 8px; padding: 6px 9px; font-size: 9px; }
-.panel-heading-actions button { min-height: 32px; border-radius: 9px; padding: 6px 10px; font-size: 10px; }
-.studio-dialog header { padding: 22px 22px 14px; }
-.studio-dialog h2 { font-size: 21px; }
-.studio-dialog label { font-size: 11px; }
-.studio-dialog input { min-height: 36px; border-radius: 9px; padding: 8px 10px; }
-.studio-dialog input:focus { border-color: var(--accent-border); box-shadow: 0 0 0 3px var(--accent-soft); }
-.studio-dialog, .role-dialog { border-radius: 16px; }
-.studio-dialog footer .primary, .role-dialog footer .primary { border-color: var(--accent); background: var(--accent); }
-
-@media (max-width: 1100px) {
-  .app-shell { grid-template-columns: 236px minmax(0, 1fr); }
-  .capabilities { display: none; }
-  .metric-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-}
-
-@media (max-width: 860px) {
-  .app-shell { grid-template-columns: 220px minmax(0, 1fr); }
-  .runtime-hero { grid-template-columns: 48px minmax(0, 1fr); }
-  .runtime-hero > img { width: 46px; height: 46px; }
-  .runtime-hero-actions { grid-column: 1 / -1; }
-}
-
-@media (max-width: 680px) {
-  .sidebar { width: min(300px, 88vw); border-right-color: var(--sidebar-line); }
-  .workspace { grid-template-rows: 58px minmax(0, 1fr); }
-  .topbar { padding-inline: 11px; }
-  .message-list { padding: 28px 14px 20px; }
-  .composer-region { padding: 0 10px 9px; }
-  .dashboard-view, .lab-view { padding: 26px 14px 42px; }
-  .page-heading h1 { font-size: 28px; }
-  .runtime-hero { padding: 15px; }
-  .metric-grid { grid-template-columns: 1fr 1fr; }
-  .model-load-policy { grid-template-columns: 1fr; }
-}
-
-@media (max-width: 420px) {
-  .metric-grid { grid-template-columns: 1fr; }
-  .runtime-hero-actions button { flex: 1; justify-content: center; }
-}
-
-/* HiveLLM-inspired desktop presentation.
-   The source application is Apache-2.0 SwiftUI; these rules translate its
-   native macOS hierarchy and spacing to MFQ Studio without changing behavior. */
-:root {
   --ink: #202122;
   --ink-strong: #111213;
   --ink-soft: #454748;
@@ -1446,27 +36,29 @@ select:focus-visible, summary:focus-visible {
   --panel-control: rgb(32 34 35 / 3.5%);
   --panel-line: rgb(32 34 35 / 8%);
   --panel-overlap-line: rgb(32 34 35 / 13%);
-  --accent: #202122;
-  --accent-hover: #050606;
-  --accent-soft: rgb(32 34 35 / 9%);
-  --accent-border: rgb(32 34 35 / 17%);
-  --accent-ink: #202122;
-  --on-accent: #ffffff;
   --sidebar: rgb(238 238 240 / 94%);
   --sidebar-surface: rgb(255 255 255 / 58%);
   --sidebar-hover: rgb(32 34 35 / 7%);
   --sidebar-line: rgb(32 34 35 / 10%);
+  --accent: #087cff;
+  --accent-hover: #0068df;
+  --accent-soft: rgb(8 124 255 / 11%);
+  --accent-border: rgb(8 124 255 / 28%);
+  --accent-ink: #0067d8;
+  --on-accent: #ffffff;
   --warning: #9e6900;
   --warning-soft: rgb(158 105 0 / 11%);
   --success: #147a43;
   --success-soft: rgb(20 122 67 / 11%);
   --danger: #b5322d;
   --danger-soft: rgb(181 50 45 / 9%);
+  --scrollbar: rgb(32 34 35 / 24%);
   --shadow-sm: 0 1px 1px rgb(0 0 0 / 2%), 0 5px 15px rgb(0 0 0 / 3%);
   --shadow-md: 0 28px 80px rgb(0 0 0 / 18%);
 }
 
 :root[data-theme="dark"] {
+  color-scheme: dark;
   --ink: #f0f1f1;
   --ink-strong: #ffffff;
   --ink-soft: #ced0d0;
@@ -1488,26 +80,30 @@ select:focus-visible, summary:focus-visible {
   --panel-control: rgb(240 243 243 / 3.5%);
   --panel-line: rgb(240 243 243 / 8%);
   --panel-overlap-line: rgb(240 243 243 / 12%);
-  --accent: #f0f1f1;
-  --accent-hover: #ffffff;
-  --accent-soft: rgb(240 243 243 / 10%);
-  --accent-border: rgb(240 243 243 / 17%);
-  --accent-ink: #f0f1f1;
-  --on-accent: #151717;
   --sidebar: rgb(20 22 22 / 96%);
   --sidebar-surface: rgb(240 243 243 / 5%);
   --sidebar-hover: rgb(240 243 243 / 8%);
   --sidebar-line: rgb(240 243 243 / 10%);
+  --accent: #0a84ff;
+  --accent-hover: #409cff;
+  --accent-soft: rgb(10 132 255 / 18%);
+  --accent-border: rgb(10 132 255 / 40%);
+  --accent-ink: #65adff;
+  --on-accent: #ffffff;
   --warning: #ffc747;
   --warning-soft: rgb(255 199 71 / 12%);
   --success: #57d184;
   --success-soft: rgb(87 209 132 / 12%);
   --danger: #ff7169;
   --danger-soft: rgb(255 113 105 / 11%);
+  --scrollbar: rgb(240 243 243 / 22%);
+  --shadow-sm: 0 1px 0 rgb(255 255 255 / 3%), 0 10px 28px rgb(0 0 0 / 16%);
+  --shadow-md: 0 28px 80px rgb(0 0 0 / 40%);
 }
 
 @media (prefers-color-scheme: dark) {
   :root[data-theme="system"] {
+    color-scheme: dark;
     --ink: #f0f1f1;
     --ink-strong: #ffffff;
     --ink-soft: #ced0d0;
@@ -1529,240 +125,96 @@ select:focus-visible, summary:focus-visible {
     --panel-control: rgb(240 243 243 / 3.5%);
     --panel-line: rgb(240 243 243 / 8%);
     --panel-overlap-line: rgb(240 243 243 / 12%);
-    --accent: #f0f1f1;
-    --accent-hover: #ffffff;
-    --accent-soft: rgb(240 243 243 / 10%);
-    --accent-border: rgb(240 243 243 / 17%);
-    --accent-ink: #f0f1f1;
-    --on-accent: #151717;
     --sidebar: rgb(20 22 22 / 96%);
     --sidebar-surface: rgb(240 243 243 / 5%);
     --sidebar-hover: rgb(240 243 243 / 8%);
     --sidebar-line: rgb(240 243 243 / 10%);
+    --accent: #0a84ff;
+    --accent-hover: #409cff;
+    --accent-soft: rgb(10 132 255 / 18%);
+    --accent-border: rgb(10 132 255 / 40%);
+    --accent-ink: #65adff;
+    --on-accent: #ffffff;
     --warning: #ffc747;
     --warning-soft: rgb(255 199 71 / 12%);
     --success: #57d184;
     --success-soft: rgb(87 209 132 / 12%);
     --danger: #ff7169;
     --danger-soft: rgb(255 113 105 / 11%);
+    --scrollbar: rgb(240 243 243 / 22%);
+    --shadow-sm: 0 1px 0 rgb(255 255 255 / 3%), 0 10px 28px rgb(0 0 0 / 16%);
+    --shadow-md: 0 28px 80px rgb(0 0 0 / 40%);
   }
 }
 
-button:focus-visible, input:focus-visible, textarea:focus-visible,
-select:focus-visible, summary:focus-visible { outline-color: rgb(83 142 144 / 40%); }
-::selection { background: #357f82; }
+/* ---------- Base ---------- */
 
-.app-shell { grid-template-columns: 232px minmax(0, 1fr); }
+* { box-sizing: border-box; }
+html, body, #root { min-width: 320px; min-height: 100%; margin: 0; }
+body { overflow: hidden; }
+button, input, textarea, select { font: inherit; }
+button { cursor: pointer; }
+button:disabled { cursor: not-allowed; opacity: 0.45; }
+button, input, textarea, select {
+  transition: border-color 130ms ease, background-color 130ms ease, color 130ms ease,
+    box-shadow 130ms ease;
+}
+button:focus-visible, input:focus-visible, textarea:focus-visible,
+select:focus-visible, summary:focus-visible {
+  outline: 2px solid rgb(10 132 255 / 42%);
+  outline-offset: 2px;
+}
+::selection { color: #fff; background: #0a84ff; }
+* { scrollbar-width: thin; scrollbar-color: var(--scrollbar) transparent; }
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}
+
+.ui-icon {
+  display: block;
+  flex: 0 0 auto;
+  stroke: currentColor;
+  stroke-width: 1.7;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+/* ---------- Shell: sidebar ---------- */
+
+.app-shell {
+  display: grid;
+  grid-template-columns: 232px minmax(0, 1fr);
+  width: 100%;
+  height: 100vh;
+  height: 100dvh;
+  overflow: hidden;
+}
+
 .sidebar {
-  border-right-color: var(--sidebar-line);
+  position: relative;
+  z-index: 10;
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  border-right: 1px solid var(--sidebar-line);
   padding: 15px 12px 12px;
   color: var(--ink);
   background: var(--sidebar);
   backdrop-filter: blur(30px) saturate(1.15);
 }
-.brand { gap: 11px; padding: 2px 8px 14px; }
-.brand img { width: 36px; height: 36px; border-radius: 10px; box-shadow: none; }
-.brand strong { font-size: 16px; font-weight: 680; letter-spacing: -0.015em; }
-.brand span { font-size: 10px; font-weight: 560; letter-spacing: 0.035em; }
-.sidebar-group-label,
-.assistant-heading,
-.history-heading {
-  padding: 11px 9px 6px;
-  color: var(--muted);
-  font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 0.065em;
-  text-transform: uppercase;
-}
-.primary-nav { gap: 3px; margin: 0 0 5px; }
-.primary-nav.inference-nav { margin-bottom: 11px; }
-.primary-nav button,
-.context-nav button {
-  min-height: 34px;
-  gap: 9px;
-  border-radius: 8px;
-  padding: 7px 9px;
-  color: var(--ink-soft);
-  font-size: 12px;
-  font-weight: 530;
-}
-.primary-nav button.active,
-.context-nav button.active {
-  color: var(--on-accent);
-  background: var(--accent);
-  box-shadow: none;
-}
-.primary-nav button span { min-width: 22px; background: rgb(127 127 127 / 17%); }
-.assistant-list { max-height: min(190px, 25vh); }
-.assistant-row { min-height: 42px; border-radius: 8px; }
-.assistant-main { grid-template-columns: 29px minmax(0, 1fr); gap: 8px; padding: 6px 8px; }
-.assistant-main > span { width: 29px; height: 29px; border-radius: 8px; color: var(--ink); }
-.assistant-list strong { font-size: 11px; }
-.assistant-list small { font-size: 9px; }
-.new-session {
-  min-height: 34px;
-  border-color: var(--sidebar-line);
-  border-radius: 8px;
-  color: var(--ink-soft);
-  background: var(--sidebar-surface);
-  font-size: 11px;
-}
-.new-session:hover { border-color: var(--line-strong); color: var(--ink); background: var(--sidebar-hover); }
-.session-row { min-height: 42px; border-radius: 8px; }
-.session-row.active { box-shadow: inset 2px 0 var(--ink); }
-.session-main { padding: 7px 9px; font-size: 11px; }
-.sidebar-runtime-card {
-  margin: 10px -12px -12px;
-  width: calc(100% + 24px);
-  border: 0;
-  border-top: 1px solid var(--sidebar-line);
-  border-radius: 0;
-  padding: 14px;
-  background: rgb(127 127 127 / 3.5%);
-}
-.sidebar-runtime-card:hover { border-color: var(--sidebar-line); background: var(--sidebar-hover); }
-.runtime-dot.busy { background: #ba7a0a; box-shadow: 0 0 0 4px rgb(186 122 10 / 12%); }
 
-.workspace { grid-template-rows: 66px minmax(0, 1fr); }
-.topbar { gap: 16px; border-bottom-color: var(--line-soft); padding: 0 23px; background: var(--surface-overlay); }
-.topbar-context { display: flex; min-width: 0; align-items: center; gap: 14px; }
-.topbar-context > strong { color: var(--ink-strong); font-size: 21px; font-weight: 660; letter-spacing: -0.025em; }
-.topbar-model { border-left: 1px solid var(--line); padding-left: 14px; }
-.topbar-model span { max-width: min(25vw, 380px); font-size: 12px; font-weight: 590; }
-.topbar-model small { font-size: 9px; }
-.topbar-runtime-status,
-.runtime-status-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  border-radius: 999px;
-  padding: 6px 9px;
-  color: var(--muted);
-  background: var(--surface-subtle);
-  font-size: 10px;
-  font-weight: 650;
-  white-space: nowrap;
-}
-.topbar-runtime-status i,
-.runtime-status-pill i { width: 7px; height: 7px; border-radius: 50%; background: var(--muted-light); }
-.topbar-runtime-status.running,
-.runtime-status-pill.running { color: var(--success); background: var(--success-soft); }
-.topbar-runtime-status.running i,
-.runtime-status-pill.running i { background: var(--success); }
-.topbar-actions > button, .sidebar-toggle { border-color: transparent; background: transparent; box-shadow: none; }
-.topbar-actions > button:hover, .sidebar-toggle:hover { border-color: var(--line); }
-.theme-switcher { border-color: var(--line); background: var(--surface-subtle); }
-.theme-switcher button[aria-pressed="true"] { color: var(--ink); }
-.quick-metrics { border-color: var(--line); }
+.brand { display: flex; align-items: center; gap: 11px; padding: 2px 8px 14px; }
+.brand img { width: 36px; height: 36px; border-radius: 10px; }
+.brand div { display: grid; gap: 0; }
+.brand strong { color: var(--ink-strong); font-size: 16px; font-weight: 680; letter-spacing: -0.015em; }
+.brand span { color: var(--muted); font-size: 10px; font-weight: 560; letter-spacing: 0.035em; }
 
-.message-list { width: min(850px, 100%); padding: 28px 24px 24px; }
-.welcome { margin-top: 15vh; }
-.welcome img { width: 54px; height: 54px; border: 0; border-radius: 14px; box-shadow: none; }
-.welcome h1, .welcome h2 { font-size: 25px; font-weight: 660; letter-spacing: -0.025em; }
-.welcome p { font-size: 13px; }
-.open-model-primary { border-color: var(--accent); color: var(--on-accent); background: var(--accent); box-shadow: none; }
-.prompt-grid button { border-color: var(--line); border-radius: 11px; background: var(--surface); box-shadow: none; }
-.message { grid-template-columns: 30px minmax(0, 1fr); gap: 12px; margin-bottom: 18px; }
-.message-assistant .message-body {
-  width: fit-content;
-  max-width: 690px;
-  border-radius: 12px;
-  padding: 15px;
-  background: rgb(127 127 127 / 6%);
-}
-.message-user { grid-template-columns: minmax(0, 1fr); padding-left: 90px; }
-.message-user .message-avatar { display: none; }
-.message-user .message-body { max-width: 690px; }
-.message-user .message-content { border: 0; border-radius: 12px; padding: 15px; background: var(--surface-user); }
-.message-avatar { width: 30px; height: 30px; border: 0; border-radius: 8px; background: transparent; box-shadow: none; }
-.message-avatar img { width: 30px; height: 30px; }
-.message-meta { margin-bottom: 8px; }
-.message-meta strong { font-size: 11px; }
-.message-meta span { font-size: 9px; }
-.rich-text { font-size: 13.5px; line-height: 1.62; }
-.message-actions { margin-top: 9px; }
-.message-actions button:hover { color: var(--ink); background: var(--accent-soft); }
-.live-message .message-avatar { box-shadow: none; }
-.thinking i { background: #4b989b; }
-
-.composer-region {
-  width: 100%;
-  max-width: none;
-  border-top: 1px solid var(--line-soft);
-  padding: 13px max(22px, calc((100% - 850px) / 2)) 10px;
-  background: var(--surface-overlay);
-  backdrop-filter: blur(20px) saturate(1.1);
-}
-.composer-region > .composer,
-.composer-region > .voice-component-banner,
-.composer-region > p { width: min(850px, 100%); margin-inline: auto; }
-.composer { border-color: var(--line); border-radius: 12px; box-shadow: none; }
-.composer:focus-within { border-color: var(--line-strong); box-shadow: 0 0 0 3px var(--accent-soft); }
-.composer textarea { min-height: 48px; padding: 12px 13px 5px; font-size: 13px; }
-.composer-toolbar { min-height: 42px; padding: 5px 7px 7px; }
-.composer-toolbar > button, .composer-toolbar select { border-color: var(--line); border-radius: 8px; background: var(--surface-subtle); }
-.composer-toolbar > button[aria-pressed="true"] { color: var(--ink); }
-.composer-toolbar .send-button { border-color: var(--accent); color: var(--on-accent); background: var(--accent); }
-.composer-toolbar .send-button.stop { border-color: var(--danger); color: #fff; background: var(--danger); }
-
-.dashboard-view, .lab-view { padding: 27px clamp(24px, 3.5vw, 52px) 48px; }
-.dashboard-view > *, .lab-view > * { width: min(1180px, 100%); }
-.page-heading { align-items: center; margin-bottom: 22px; }
-.page-heading h1 { margin: 0; font-size: 28px; font-weight: 660; letter-spacing: -0.035em; }
-.page-heading p { margin-top: 5px; color: var(--muted); font-size: 12px; font-weight: 400; letter-spacing: 0; text-transform: none; }
-.page-heading > button { border-color: var(--line); border-radius: 9px; box-shadow: none; }
-.runtime-hero,
-.metric-grid article,
-.dashboard-panel {
-  border: 1px solid var(--panel-line);
-  border-radius: 12px;
-  background: var(--panel-surface);
-  box-shadow: none;
-}
-.runtime-hero { grid-template-columns: 54px minmax(0, 1fr) auto; gap: 18px; padding: 19px; }
-.runtime-hero > img { width: 54px; height: 54px; border: 0; border-radius: 14px; box-shadow: none; }
-.runtime-hero h2 { font-size: 18px; font-weight: 650; }
-.runtime-hero p { font-size: 11px; }
-.runtime-hero-actions button { border-color: var(--line); border-radius: 9px; box-shadow: none; }
-.runtime-hero-actions button.primary { border-color: var(--accent); color: var(--on-accent); background: var(--accent); }
-.metric-grid { gap: 12px; }
-.metric-grid article { min-height: 112px; align-content: start; padding: 16px; text-align: left; }
-.metric-grid span { font-size: 9px; font-weight: 700; letter-spacing: 0.055em; }
-.metric-grid strong { margin: 10px 0 4px; font-size: 24px; font-weight: 580; }
-.metric-grid small { font-size: 9px; }
-.dashboard-panel { padding: 18px; }
-.panel-heading h2 { font-size: 15px; font-weight: 640; }
-.panel-heading p { font-size: 10px; }
-.panel-heading b, .request-row > b { color: var(--ink-soft); }
-.panel-heading-actions button { border-color: var(--line); color: var(--ink-soft); background: var(--surface); }
-.panel-action { border-color: var(--line); background: var(--panel-control); }
-.request-stats > div, .cache-stats > div { border-left-color: var(--line-strong); }
-.runtime-chart polyline { stroke: #35888a; }
-.model-load-policy > label { background: var(--panel-control); }
-
-.studio-dialog input:focus { border-color: var(--line-strong); box-shadow: 0 0 0 3px var(--accent-soft); }
-.studio-dialog, .role-dialog { border-color: var(--line); border-radius: 14px; }
-
-@media (max-width: 1220px) {
-  .capabilities { display: none; }
-  .topbar-model span { max-width: 24vw; }
-}
-
-@media (max-width: 980px) {
-  .app-shell { grid-template-columns: 220px minmax(0, 1fr); }
-  .topbar-runtime-status { display: none; }
-  .quick-metrics { display: none; }
-}
-
-@media (max-width: 680px) {
-  .topbar-context > strong { font-size: 18px; }
-  .topbar-model { display: none; }
-  .composer-region { padding-inline: 10px; }
-  .message-user { padding-left: 32px; }
-}
-
-/* HiveLLM-style information architecture. This block owns the desktop shell,
-   page headers, fixed navigation groups, and chat workspace composition. */
 .sidebar-scroll {
   display: flex;
   min-height: 0;
@@ -1773,17 +225,16 @@ select:focus-visible, summary:focus-visible { outline-color: rgb(83 142 144 / 40
   overflow-y: auto;
 }
 
-.sectioned-nav {
-  display: grid;
-  flex: 0 0 auto;
-  gap: 12px;
+.sectioned-nav { display: grid; flex: 0 0 auto; gap: 15px; }
+.sectioned-nav > section { display: grid; gap: 3px; }
+.sectioned-nav .sidebar-group-label {
+  padding: 2px 9px 4px;
+  color: var(--muted);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.065em;
+  text-transform: uppercase;
 }
-
-.sectioned-nav > section {
-  display: grid;
-  gap: 3px;
-}
-
 .sectioned-nav button {
   display: flex;
   width: 100%;
@@ -1799,17 +250,9 @@ select:focus-visible, summary:focus-visible { outline-color: rgb(83 142 144 / 40
   font-weight: 540;
   text-align: left;
 }
-
-.sectioned-nav button:hover {
-  color: var(--ink);
-  background: var(--sidebar-hover);
-}
-
-.sectioned-nav button.active {
-  color: var(--on-accent);
-  background: var(--accent);
-}
-
+.sectioned-nav button:hover { color: var(--ink); background: var(--sidebar-hover); }
+.sectioned-nav button.active { color: var(--on-accent); background: var(--accent); }
+.sectioned-nav button.active .ui-icon { color: currentColor; }
 .sectioned-nav button > span {
   min-width: 22px;
   margin-left: auto;
@@ -1821,265 +264,68 @@ select:focus-visible, summary:focus-visible { outline-color: rgb(83 142 144 / 40
   text-align: center;
 }
 
-.sectioned-nav .sidebar-group-label {
-  padding: 2px 9px 4px;
-}
-
-.conversation-library {
-  display: flex;
-  min-height: 310px;
-  flex: 1;
-  flex-direction: column;
+.sidebar-runtime-card {
+  display: grid;
+  width: calc(100% + 24px);
+  grid-template-columns: 9px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 9px;
+  border: 0;
   border-top: 1px solid var(--sidebar-line);
-  margin-top: 14px;
-  padding-top: 2px;
-}
-
-.conversation-library .assistant-list { max-height: min(152px, 19vh); }
-.conversation-library .session-list { min-height: 110px; flex: 1; }
-.conversation-library > .new-session { margin-bottom: 10px; }
-
-.workspace { grid-template-rows: 48px minmax(0, 1fr); }
-.topbar { padding-inline: 20px; }
-.topbar-context { gap: 8px; }
-.topbar-context > span,
-.topbar-context > i {
-  color: var(--muted-light);
-  font-size: 10px;
-  font-style: normal;
-  font-weight: 560;
-}
-.topbar-context > strong {
+  border-radius: 0;
+  margin: 10px -12px -12px;
+  padding: 14px;
   color: var(--ink-soft);
-  font-size: 11px;
-  font-weight: 640;
-  letter-spacing: 0;
+  background: rgb(127 127 127 / 3.5%);
+  text-align: left;
 }
-.topbar-actions .topbar-model {
-  min-width: 120px;
-  align-items: end;
-  border-right: 1px solid var(--line);
-  margin-right: 3px;
-  padding-right: 12px;
-  text-align: right;
+.sidebar-runtime-card:hover { border-color: var(--sidebar-line); background: var(--sidebar-hover); }
+.sidebar-runtime-card > span:nth-child(2) { display: grid; min-width: 0; gap: 2px; }
+.sidebar-runtime-card strong, .sidebar-runtime-card small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
-.topbar-actions .topbar-model span { max-width: min(21vw, 280px); font-size: 10px; }
-.topbar-actions .topbar-model small { font-size: 8px; }
-.topbar .capabilities,
-.topbar .quick-metrics { display: none; }
+.sidebar-runtime-card strong { font-size: 11px; font-weight: 620; }
+.sidebar-runtime-card small { color: var(--muted); font-size: 9px; }
+.runtime-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--muted-light); }
+.runtime-dot.ready { background: var(--success); box-shadow: 0 0 0 4px var(--success-soft); }
+.runtime-dot.busy { background: var(--accent); box-shadow: 0 0 0 4px var(--accent-soft); }
 
-.chat-view {
-  grid-template-rows: auto minmax(0, 1fr) auto auto;
+.mobile-scrim { display: none; }
+
+/* ---------- Workspace and page column ---------- */
+
+.workspace {
+  display: grid;
+  min-width: 0;
+  min-height: 0;
+  grid-template-rows: minmax(0, 1fr);
   background: var(--canvas);
 }
 
-.chat-screen-header {
-  display: flex;
-  min-width: 0;
-  align-items: center;
-  justify-content: space-between;
-  gap: 24px;
-  border-bottom: 1px solid var(--line);
-  padding: 17px 24px;
-  background: var(--surface-overlay);
+.dashboard-view, .lab-view {
+  min-height: 0;
+  overflow-y: auto;
+  padding: 27px clamp(24px, 3.5vw, 52px) 48px;
+  background: var(--canvas);
 }
-
-.chat-screen-title { min-width: 0; }
-.chat-screen-title > span,
-.page-eyebrow {
-  display: block;
-  margin-bottom: 4px;
-  color: var(--muted);
-  font-size: 8px;
-  font-weight: 720;
-  letter-spacing: 0.085em;
-  text-transform: uppercase;
-}
-.chat-screen-title h1 {
-  overflow: hidden;
-  max-width: min(44vw, 600px);
-  margin: 0;
-  color: var(--ink-strong);
-  font-size: 20px;
-  font-weight: 660;
-  letter-spacing: -0.025em;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.chat-screen-title p {
-  margin: 4px 0 0;
-  color: var(--muted);
-  font-size: 10px;
-}
-
-.chat-screen-actions {
-  display: flex;
-  min-width: 0;
-  align-items: center;
-  gap: 10px;
-}
-.chat-model-summary {
-  display: grid;
-  min-width: 0;
-  gap: 2px;
-  text-align: right;
-}
-.chat-model-summary strong {
-  overflow: hidden;
-  max-width: min(27vw, 350px);
-  color: var(--ink-soft);
-  font-size: 11px;
-  font-weight: 630;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.chat-model-summary small { color: var(--muted); font-size: 8px; white-space: nowrap; }
-.chat-header-button {
-  display: inline-flex;
-  min-height: 32px;
-  align-items: center;
-  gap: 7px;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  padding: 7px 10px;
-  color: var(--ink-soft);
-  background: var(--surface);
-  font-size: 10px;
-  font-weight: 620;
-}
-.chat-header-button:hover { border-color: var(--line-strong); color: var(--ink); background: var(--surface-hover); }
-
-.message-list { padding-top: 24px; }
-.welcome { margin-top: clamp(35px, 10vh, 110px); }
+.dashboard-view > *, .lab-view > * { width: min(1180px, 100%); margin-inline: auto; }
 
 .page-heading {
-  min-height: 72px;
-  border-bottom: 1px solid var(--line-soft);
-  margin-bottom: 24px;
-  padding-bottom: 18px;
-}
-.page-heading h1 { font-size: 30px; }
-.page-heading > button { align-self: center; }
-
-.panel-deck.page-dashboard-models {
-  grid-template-columns: repeat(12, minmax(0, 1fr));
-}
-.panel-deck.page-dashboard-models > [data-panel-id="catalog"] {
-  grid-column: 1 / -1;
-  grid-row: 1;
-}
-.panel-deck.page-dashboard-models > [data-panel-id="requests"] {
-  grid-column: 1 / span 6;
-  grid-row: 2;
-}
-.panel-deck.page-dashboard-models > [data-panel-id="jobs"] {
-  grid-column: 7 / -1;
-  grid-row: 2;
-}
-.panel-deck.page-dashboard-models > [data-panel-id="logs"] {
-  grid-column: 1 / -1;
-  grid-row: 3;
-}
-.panel-deck.page-dashboard-cache { grid-template-columns: 1fr; }
-.panel-deck.page-dashboard-cache > .panel-shell { grid-column: 1; }
-.panel-deck.page-lab-models { grid-template-columns: 1fr; }
-.panel-deck.page-lab-models > .panel-shell { grid-column: 1; }
-
-.model-catalog-panel .model-list {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px;
-}
-.model-catalog-panel .model-row {
-  border: 1px solid var(--line-soft);
-  border-radius: 9px;
-  padding-inline: 10px;
-  background: var(--panel-control);
-}
-
-.panel-deck .panel-drag,
-.panel-deck .panel-collapse { opacity: 0; transition: opacity 120ms ease, background-color 120ms ease; }
-.panel-shell:hover > .panel-drag,
-.panel-shell:hover > .panel-collapse,
-.panel-shell:focus-within > .panel-drag,
-.panel-shell:focus-within > .panel-collapse { opacity: 1; }
-
-@media (max-width: 1080px) {
-  .chat-screen-title p { display: none; }
-  .chat-model-summary small { display: none; }
-  .topbar-actions .topbar-model { display: none; }
-}
-
-@media (max-width: 760px) {
-  .chat-screen-header { align-items: flex-start; padding: 14px; }
-  .chat-model-summary { display: none; }
-  .chat-screen-title h1 { max-width: 48vw; font-size: 17px; }
-  .runtime-status-pill { display: none; }
-  .page-heading { min-height: 0; }
-  .panel-deck.page-dashboard-models { grid-template-columns: 1fr; }
-  .panel-deck.page-dashboard-models > [data-panel-id] { grid-column: 1; grid-row: auto; }
-  .model-catalog-panel .model-list { grid-template-columns: 1fr; }
-}
-
-/* Backend-console simplification: mirror HiveLLM's quiet split-view shell. */
-.conversation-library { display: none !important; }
-.workspace { grid-template-rows: minmax(0, 1fr); }
-.sidebar-scroll { overflow-y: auto; }
-.sectioned-nav { gap: 15px; }
-
-.panel-deck.static .panel-drag,
-.panel-deck.static .panel-collapse,
-.panel-deck.static .panel-overlap-layer { display: none; }
-.panel-deck.static .panel-shell {
-  width: auto !important;
-  height: auto !important;
-  transform: none !important;
-  cursor: default !important;
-}
-.panel-deck.static .panel-heading { padding-right: 0; }
-
-.chat-screen-header {
-  min-height: 70px;
-  padding-block: 14px;
-}
-.chat-screen-title h1 { max-width: none; font-size: 20px; }
-.chat-icon-button {
-  display: grid;
-  width: 31px;
-  height: 31px;
-  flex: 0 0 auto;
-  place-items: center;
-  border: 1px solid transparent;
-  border-radius: 8px;
-  padding: 0;
-  color: var(--muted);
-  background: transparent;
-}
-.chat-icon-button:hover { border-color: var(--line); color: var(--danger); background: var(--surface-subtle); }
-.welcome > .ui-icon { margin-bottom: 16px; color: var(--muted); stroke-width: 1.25; }
-
-.page-heading {
+  display: flex;
   min-height: 58px;
   align-items: flex-start;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--line-soft);
   margin-bottom: 22px;
   padding-bottom: 16px;
 }
-.page-heading h1 { margin: 0 0 5px; font-size: 27px; }
-.page-heading p { color: var(--muted); font-size: 11px; font-weight: 400; letter-spacing: 0; text-transform: none; }
+.page-heading h1 { margin: 0 0 5px; color: var(--ink-strong); font-size: 27px; font-weight: 660; letter-spacing: -0.035em; }
+.page-heading p { margin: 0; color: var(--muted); font-size: 11px; font-weight: 400; letter-spacing: 0; text-transform: none; }
 
-.panel-deck.page-dashboard-models { grid-template-columns: 1fr; }
-.panel-deck.page-dashboard-models > [data-panel-id="catalog"] { grid-column: 1; }
-.panel-deck.page-dashboard-logs {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-.panel-deck.page-dashboard-logs > [data-panel-id="logs"] { grid-column: 1 / -1; }
+/* ---------- Shared components ---------- */
 
-@media (max-width: 760px) {
-  .panel-deck.page-dashboard-logs { grid-template-columns: 1fr; }
-  .panel-deck.page-dashboard-logs > [data-panel-id] { grid-column: 1; }
-}
-
-/* HiveLLM interior component language. */
 .screen-header {
   display: flex;
   min-height: 64px;
@@ -2096,18 +342,8 @@ select:focus-visible, summary:focus-visible { outline-color: rgb(83 142 144 / 40
   font-weight: 660;
   letter-spacing: -0.035em;
 }
-.screen-header p {
-  margin: 6px 0 0;
-  color: var(--muted);
-  font-size: 12px;
-  line-height: 1.55;
-}
-.screen-header-trailing {
-  display: flex;
-  flex: 0 0 auto;
-  align-items: center;
-  gap: 8px;
-}
+.screen-header p { margin: 6px 0 0; color: var(--muted); font-size: 12px; line-height: 1.55; }
+.screen-header-trailing { display: flex; flex: 0 0 auto; align-items: center; gap: 8px; }
 .screen-header-trailing button {
   display: inline-flex;
   min-height: 32px;
@@ -2150,6 +386,25 @@ select:focus-visible, summary:focus-visible { outline-color: rgb(83 142 144 / 40
 .tm-panel .panel-heading h2 { font-size: 15px; line-height: 1.35; }
 .tm-panel .panel-heading p { font-size: 11px; line-height: 1.5; }
 
+.panel-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 14px; }
+.panel-heading h2 { margin: 0 0 3px; font-size: 15px; font-weight: 640; }
+.panel-heading p { margin: 0; color: var(--muted); font-size: 10px; line-height: 1.45; }
+.panel-heading b { color: var(--ink-soft); font-size: 11px; font-weight: 620; }
+.panel-heading-actions { display: flex; align-items: center; gap: 8px; }
+.panel-heading-actions button {
+  min-height: 32px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  padding: 6px 10px;
+  color: var(--ink-soft);
+  background: var(--surface);
+  font-size: 10px;
+}
+.panel-heading-actions button:hover { border-color: var(--line-strong); color: var(--ink); background: var(--surface-hover); }
+
+button.primary { border-color: var(--accent); color: var(--on-accent); background: var(--accent); }
+button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent); background: var(--accent-hover); }
+
 .metric-grid {
   display: grid;
   grid-template-columns: repeat(5, minmax(0, 1fr));
@@ -2158,9 +413,13 @@ select:focus-visible, summary:focus-visible { outline-color: rgb(83 142 144 / 40
 }
 .metric-grid > .metric-tile {
   display: grid;
-  min-height: 124px;
+  min-height: 112px;
   align-content: start;
-  padding: 17px;
+  border: 1px solid var(--panel-line);
+  border-radius: 12px;
+  padding: 16px;
+  background: var(--panel-surface);
+  box-shadow: none;
   text-align: left;
 }
 .metric-tile-label { display: flex; align-items: center; gap: 7px; color: var(--muted); }
@@ -2168,13 +427,13 @@ select:focus-visible, summary:focus-visible { outline-color: rgb(83 142 144 / 40
 .metric-tile-label span {
   color: inherit;
   font-size: 10px;
-  font-weight: 720;
-  letter-spacing: 0.045em;
+  font-weight: 700;
+  letter-spacing: 0.055em;
   text-transform: uppercase;
 }
 .metric-grid > .metric-tile > strong {
   overflow: hidden;
-  margin: 14px 0 6px;
+  margin: 10px 0 4px;
   color: var(--ink-strong);
   font-size: 24px;
   font-weight: 580;
@@ -2184,12 +443,18 @@ select:focus-visible, summary:focus-visible { outline-color: rgb(83 142 144 / 40
 }
 .metric-grid > .metric-tile > small { color: var(--muted-light); font-size: 11px; line-height: 1.45; }
 
-.dashboard-grid { display: grid; gap: 14px; }
+.dashboard-grid { display: grid; grid-template-columns: minmax(0, 2fr) minmax(260px, 1fr); gap: 14px; }
 .logs-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 .logs-grid > .runtime-log-panel { grid-column: 1 / -1; }
 .server-tools-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 .server-tools-grid .mcp-panel,
 .server-tools-grid .cluster-panel { height: 100%; margin: 0; }
+
+.dashboard-panel { border: 1px solid var(--panel-line); border-radius: 12px; padding: 18px; background: var(--panel-surface); box-shadow: none; }
+.dashboard-panel dl { margin: 12px 0 0; }
+.dashboard-panel dl div { display: grid; grid-template-columns: 105px minmax(0, 1fr); border-top: 1px solid var(--panel-line); padding: 10px 0; }
+.dashboard-panel dt { color: var(--muted); font-size: 11px; }
+.dashboard-panel dd { overflow: hidden; margin: 0; color: var(--ink-soft); font-size: 11px; text-overflow: ellipsis; white-space: nowrap; }
 
 .setting-list { display: grid; }
 .setting-row {
@@ -2225,89 +490,6 @@ select:focus-visible, summary:focus-visible { outline-color: rgb(83 142 144 / 40
   background: var(--panel-control);
   font-size: 9px;
 }
-.model-policy-panel { margin-top: 8px; }
-
-.settings-page { display: grid; }
-.settings-page > .section-label:first-child { margin-top: 2px; }
-.settings-page-inherited {
-  min-width: 0;
-  border: 0;
-  margin: 0;
-  padding: 0;
-}
-.settings-page-inherited:disabled { opacity: 0.52; }
-.settings-page-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 14px;
-}
-.settings-page-section { display: grid; min-width: 0; align-content: start; }
-.settings-page-panel { min-width: 0; }
-.settings-defaults-panel { padding-block: 15px; }
-.settings-defaults-panel input[type="checkbox"],
-.settings-form-panel input[type="checkbox"] { accent-color: var(--accent); }
-.settings-form-panel { display: grid; align-content: start; gap: 15px; }
-.settings-control-block { display: grid; gap: 8px; }
-.settings-control-block > label,
-.settings-range > span,
-.settings-inline-fields label > span,
-.settings-page .saved-presets label > span {
-  color: var(--muted);
-  font-size: 10px;
-  font-weight: 610;
-  line-height: 1.45;
-}
-.settings-page .segmented { gap: 4px; }
-.settings-page .segmented button,
-.settings-page button,
-.settings-page .portable-actions label {
-  min-height: 32px;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  padding: 6px 11px;
-  color: var(--ink-soft);
-  background: var(--panel-control);
-  font-size: 10px;
-  font-weight: 610;
-}
-.settings-page button:hover,
-.settings-page .portable-actions label:hover { border-color: var(--line-strong); background: var(--surface-hover); }
-.settings-page button.primary { border-color: var(--accent); color: var(--on-accent); background: var(--accent); }
-.settings-page textarea,
-.settings-page input:not([type="checkbox"]):not([type="range"]),
-.settings-page select {
-  width: 100%;
-  min-height: 34px;
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  outline: 0;
-  padding: 7px 9px;
-  color: var(--ink-soft);
-  background: var(--panel-control);
-  font-size: 10px;
-}
-.settings-page textarea { resize: vertical; line-height: 1.5; }
-.settings-page textarea:focus,
-.settings-page input:not([type="checkbox"]):not([type="range"]):focus,
-.settings-page select:focus { border-color: var(--line-strong); box-shadow: 0 0 0 3px var(--accent-soft); }
-.settings-page .saved-presets { gap: 9px; margin-top: 0; padding-top: 15px; }
-.settings-page .saved-presets label { display: grid; gap: 6px; }
-.settings-page .saved-presets > small { font-size: 10px; line-height: 1.5; }
-.settings-page .preset-status { font-size: 10px; }
-.settings-range { display: grid; gap: 8px; }
-.settings-range + .settings-range { border-top: 1px solid var(--line-soft); padding-top: 14px; }
-.settings-range > span { display: flex; justify-content: space-between; gap: 14px; }
-.settings-range output { color: var(--ink-soft); font: 10px/1.45 ui-monospace, SFMono-Regular, Menlo, monospace; }
-.settings-range input { width: 100%; accent-color: var(--accent); }
-.settings-inline-fields { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; border-top: 1px solid var(--line-soft); padding-top: 14px; }
-.settings-inline-fields label { display: grid; gap: 6px; }
-.settings-number-input { width: 112px !important; text-align: right; }
-.settings-context-input { width: 146px !important; }
-.settings-panel-actions { display: flex; justify-content: flex-end; border-top: 1px solid var(--line-soft); margin-top: 2px; padding-top: 14px; }
-.settings-data-panel { padding-block: 15px; }
-.settings-page .portable-actions { flex-wrap: nowrap; }
-.settings-page .portable-actions label { display: grid; place-items: center; margin: 0; cursor: pointer; }
-.settings-page-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 18px; }
 
 .usage-bar { display: grid; gap: 8px; }
 .usage-bar + .usage-bar { margin-top: 18px; }
@@ -2316,7 +498,6 @@ select:focus-visible, summary:focus-visible { outline-color: rgb(83 142 144 / 40
 .usage-bar span { color: var(--muted); font: 10px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; }
 .usage-bar-track { height: 7px; overflow: hidden; border-radius: 999px; background: rgb(127 127 127 / 10%); }
 .usage-bar-track i { display: block; height: 100%; border-radius: inherit; background: var(--accent); }
-.cache-usage-bars { margin: 17px 0 20px; }
 
 .empty-panel {
   display: grid;
@@ -2331,14 +512,6 @@ select:focus-visible, summary:focus-visible { outline-color: rgb(83 142 144 / 40
 .empty-panel > p { max-width: 480px; margin: 0; color: var(--muted); font-size: 10px; line-height: 1.5; }
 .inline-empty { padding: 24px 0 8px; color: var(--muted); font-size: 10px; text-align: center; }
 
-.tm-panel.runtime-hero {
-  display: grid;
-  grid-template-columns: 54px minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 18px;
-  margin: 0;
-  padding: 20px;
-}
 .model-monogram {
   display: grid;
   width: 54px;
@@ -2353,28 +526,176 @@ select:focus-visible, summary:focus-visible { outline-color: rgb(83 142 144 / 40
 .model-monogram.loading { color: var(--warning); }
 .model-monogram.ready { color: var(--success); }
 .model-monogram.failed { color: var(--danger); }
+
+.runtime-status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: 999px;
+  padding: 6px 9px;
+  color: var(--muted);
+  background: var(--surface-subtle);
+  font-size: 10px;
+  font-weight: 650;
+  white-space: nowrap;
+}
+.runtime-status-pill i { width: 7px; height: 7px; border-radius: 50%; background: var(--muted-light); }
+.runtime-status-pill.running { color: var(--success); background: var(--success-soft); }
+.runtime-status-pill.running i { background: var(--success); }
 .runtime-status-pill.loading { color: var(--warning); background: var(--warning-soft); }
 .runtime-status-pill.loading i { background: var(--warning); }
 .runtime-status-pill.ready { color: var(--success); background: var(--success-soft); }
 .runtime-status-pill.ready i { background: var(--success); }
 .runtime-status-pill.failed { color: var(--danger); background: var(--danger-soft); }
 .runtime-status-pill.failed i { background: var(--danger); }
-.runtime-hero-copy { display: grid; gap: 5px; }
+
+/* ---------- Draggable panel deck (dormant while static) ---------- */
+
+.panel-deck { position: relative; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 13px; }
+.panel-deck.single { grid-template-columns: 1fr; }
+.panel-deck.page-dashboard-models,
+.panel-deck.page-dashboard-cache,
+.panel-deck.page-lab-models { grid-template-columns: 1fr; }
+.panel-deck.page-dashboard-logs { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.panel-deck.page-dashboard-logs > [data-panel-id="logs"] { grid-column: 1 / -1; }
+
+.panel-shell {
+  position: relative;
+  min-width: 0;
+  overflow: hidden;
+  container-type: inline-size;
+  transition: opacity 140ms ease, transform 140ms ease;
+}
+.panel-shell.wide { grid-column: 1 / -1; }
+.panel-shell > .dashboard-panel, .panel-shell > .metric-grid, .panel-shell > div > .dashboard-panel { width: 100%; height: 100%; margin: 0; }
+.panel-deck .panel-shell { transform: translate3d(var(--panel-x, 0), var(--panel-y, 0), 0); }
+.panel-deck .panel-shell.dragging { opacity: 0.72; transform: translate3d(var(--panel-x), var(--panel-y), 0) scale(0.992); transition-duration: 0s; }
+.panel-deck .panel-shell.resizing { transition-duration: 0s; }
+
+.panel-drag, .panel-collapse {
+  position: absolute;
+  z-index: 2;
+  top: 11px;
+  display: grid;
+  width: 23px;
+  height: 23px;
+  place-items: center;
+  border: 0;
+  border-radius: 6px;
+  padding: 0;
+  color: var(--muted-light);
+  background: transparent;
+}
+.panel-drag { right: 38px; grid-template-columns: repeat(2, 2px); grid-template-rows: repeat(3, 2px); place-content: center; gap: 2px; cursor: grab; touch-action: none; user-select: none; -webkit-user-select: none; }
+.panel-drag:active { cursor: grabbing; }
+.panel-drag span { width: 2px; height: 2px; border-radius: 50%; background: currentColor; }
+.panel-collapse { right: 10px; font-size: 15px; line-height: 1; transition: transform 130ms ease; }
+.panel-drag:hover, .panel-collapse:hover { color: var(--ink); background: rgb(127 132 129 / 8%); }
+.panel-shell.collapsed .panel-collapse { transform: rotate(-90deg); }
+.panel-shell.collapsed > :not(.panel-drag):not(.panel-collapse) { height: 47px; min-height: 47px; overflow: hidden; }
+.panel-shell.collapsed .dashboard-panel, .panel-shell.collapsed .metric-grid { padding-bottom: 0; }
+.panel-shell.collapsed .dashboard-panel > :not(.panel-heading),
+.panel-shell.collapsed .metric-grid > article:not(:first-child),
+.panel-shell.collapsed > div > .dashboard-panel > :not(.panel-heading) { display: none; }
+.panel-shell.collapsed .metric-grid { display: block; }
+.panel-shell.collapsed .metric-grid article:first-child { display: flex; height: 47px; align-items: center; gap: 9px; padding-block: 0; }
+.panel-shell.collapsed .metric-grid article:first-child strong { margin-left: auto; }
+.panel-shell .panel-heading { padding-right: 54px; }
+.panel-deck.static .panel-heading { padding-right: 0; }
+.panel-deck.static .panel-drag,
+.panel-deck.static .panel-collapse,
+.panel-deck.static .panel-overlap-layer { display: none; }
+.panel-deck.static .panel-shell {
+  width: auto !important;
+  height: auto !important;
+  transform: none !important;
+  cursor: default !important;
+}
+.panel-reordering, .panel-reordering * { cursor: grabbing !important; user-select: none !important; -webkit-user-select: none !important; }
+.panel-resizing, .panel-resizing * { user-select: none !important; -webkit-user-select: none !important; }
+.panel-item-clipped { display: none !important; }
+
+.panel-overlap-layer { position: absolute; z-index: 2147483647; inset: 0; overflow: visible; pointer-events: none; }
+.panel-overlap-boundary { position: absolute; box-sizing: border-box; }
+.panel-overlap-boundary.edge-top { border-top: 1px solid var(--panel-overlap-line); }
+.panel-overlap-boundary.edge-right { border-right: 1px solid var(--panel-overlap-line); }
+.panel-overlap-boundary.edge-bottom { border-bottom: 1px solid var(--panel-overlap-line); }
+.panel-overlap-boundary.edge-left { border-left: 1px solid var(--panel-overlap-line); }
+.panel-overlap-boundary.edge-top.edge-left { border-top-left-radius: 11px; }
+.panel-overlap-boundary.edge-top.edge-right { border-top-right-radius: 11px; }
+.panel-overlap-boundary.edge-bottom.edge-right { border-bottom-right-radius: 11px; }
+.panel-overlap-boundary.edge-bottom.edge-left { border-bottom-left-radius: 11px; }
+
+.model-catalog-panel .model-list { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; }
+.model-catalog-panel .model-row {
+  border: 1px solid var(--line-soft);
+  border-radius: 9px;
+  padding-inline: 10px;
+  background: var(--panel-control);
+}
+
+.model-list, .request-table { display: grid; gap: 2px; margin-top: 15px; }
+.model-row, .request-row { display: grid; min-width: 0; align-items: center; border-top: 1px solid var(--panel-line); padding: 12px 2px; }
+.model-row { grid-template-columns: 8px minmax(0, 1fr) auto; gap: 9px; }
+.request-row { grid-template-columns: minmax(0, 1fr) auto 74px; gap: 12px; }
+.model-state { width: 7px; height: 7px; border-radius: 50%; background: var(--muted-light); }
+.model-state.active { background: var(--success); box-shadow: 0 0 0 3px var(--success-soft); }
+.model-state.failed { background: var(--danger); }
+.model-row div, .request-row div { display: grid; min-width: 0; gap: 2px; }
+.model-row strong, .request-row strong { overflow: hidden; color: var(--ink-soft); font-size: 11px; font-weight: 620; text-overflow: ellipsis; white-space: nowrap; }
+.model-row small, .request-row small, .request-row > span { color: var(--muted-light); font-size: 9px; }
+.model-row em { border-radius: 999px; padding: 2px 6px; color: var(--success); background: var(--success-soft); font-size: 8px; font-style: normal; }
+.model-row em.failed { color: var(--danger); background: var(--danger-soft); }
+.model-row > button { border: 1px solid var(--panel-line); border-radius: 8px; padding: 6px 9px; color: var(--accent-ink); background: var(--panel-control); font-size: 9px; }
+.model-row > button:hover { border-color: var(--accent-border); background: var(--accent-soft); }
+.request-row > b { color: var(--ink-soft); font-size: 11px; font-weight: 620; text-align: right; }
+
+/* Neutral single-style monitor chart contract (kept for parity with the
+   runtime metrics API; the console currently renders tiles instead). */
+.runtime-chart { width: 100%; height: 225px; margin-top: 18px; overflow: visible; }
+.runtime-chart line { stroke: var(--line-soft); stroke-width: 0.42; }
+.runtime-chart polyline { fill: none; stroke: var(--accent); stroke-linecap: round; stroke-linejoin: round; stroke-width: 2; vector-effect: non-scaling-stroke; }
+
+/* ---------- Overview page ---------- */
+
+.tm-panel.runtime-hero {
+  display: grid;
+  grid-template-columns: 54px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 18px;
+  margin: 0;
+  padding: 20px;
+}
+.runtime-hero-copy { display: grid; min-width: 0; gap: 5px; }
 .runtime-hero-copy > div { display: flex; min-width: 0; align-items: center; gap: 9px; }
+.runtime-hero h2 { overflow: hidden; margin: 0; color: var(--ink-strong); font-size: 18px; font-weight: 650; text-overflow: ellipsis; white-space: nowrap; }
 .runtime-hero-copy > p.runtime-endpoint {
   margin: 0;
   color: var(--muted);
   font: 11px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 .runtime-hero-copy > small { color: var(--muted-light); font-size: 10px; line-height: 1.5; }
+.runtime-hero-actions { display: flex; gap: 8px; }
+.runtime-hero-actions button {
+  display: inline-flex;
+  min-height: 36px;
+  align-items: center;
+  gap: 7px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  padding: 7px 12px;
+  color: var(--ink-soft);
+  background: var(--surface);
+  font-size: 11px;
+  font-weight: 590;
+  box-shadow: none;
+}
+.runtime-hero-actions button:hover { border-color: var(--line-strong); background: var(--surface-hover); }
+.runtime-hero-actions button.primary { border-color: var(--accent); color: var(--on-accent); background: var(--accent); }
+.runtime-hero-actions button.primary:hover { border-color: var(--accent-hover); background: var(--accent-hover); }
 
 .overview-memory-panel { padding: 19px; }
-.overview-memory-heading {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 24px;
-}
+.overview-memory-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 24px; }
 .overview-memory-heading h2,
 .overview-panel-title h2 { margin: 0; color: var(--ink-soft); font-size: 15px; font-weight: 640; line-height: 1.35; }
 .overview-memory-heading p { margin: 5px 0 0; color: var(--muted); font-size: 11px; line-height: 1.55; }
@@ -2392,12 +713,7 @@ select:focus-visible, summary:focus-visible { outline-color: rgb(83 142 144 / 40
 .overview-memory-facts span { display: inline-flex; align-items: center; gap: 7px; color: var(--muted); font-size: 10px; line-height: 1.45; }
 .overview-memory-facts .ui-icon { color: var(--muted-light); }
 
-.overview-footer-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 14px;
-  margin-top: 14px;
-}
+.overview-footer-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; margin-top: 14px; }
 .overview-endpoint-panel,
 .overview-session-panel { display: grid; align-content: start; gap: 15px; min-height: 158px; }
 .overview-panel-title { display: flex; min-width: 0; align-items: center; gap: 8px; }
@@ -2430,9 +746,89 @@ select:focus-visible, summary:focus-visible { outline-color: rgb(83 142 144 / 40
 .overview-session-stats > div { display: grid; gap: 3px; }
 .overview-session-stats strong { color: var(--ink-soft); font: 600 15px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; }
 .overview-session-stats small { color: var(--muted-light); font-size: 10px; line-height: 1.4; }
-.model-library-panel .model-list { margin-top: 0; }
-.profile-panel,
-.cache-panel { margin-top: 0; }
+
+/* ---------- Cache and profiles page ---------- */
+
+.cache-usage-bars { margin: 17px 0 20px; }
+.cache-stats { display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px; margin-top: 17px; }
+.cache-stats > div { display: grid; gap: 2px; border-left: 2px solid var(--line-strong); padding-left: 11px; }
+.cache-stats span { color: var(--muted-light); font-size: 10px; }
+.cache-stats strong { color: var(--ink-soft); font-size: 14px; font-weight: 620; }
+.cache-stats strong small { margin-left: 5px; color: var(--muted-light); font-size: 9px; font-weight: 500; }
+
+.profile-panel { margin-top: 0; }
+.profile-create { display: grid; grid-template-columns: minmax(180px, 1fr) auto; gap: 7px; margin-top: 12px; }
+.profile-create input { min-width: 0; border: 1px solid var(--panel-line); border-radius: 7px; padding: 7px 9px; color: var(--ink-soft); background: var(--panel-control); font-size: 10px; }
+.profile-create button, .profile-row button { border: 1px solid var(--panel-line); border-radius: 7px; padding: 6px 9px; color: var(--ink-soft); background: var(--panel-control); font-size: 9px; }
+.profile-create button:hover, .profile-row button:hover { border-color: var(--line-strong); color: var(--ink); background: var(--surface-hover); }
+.profile-list { display: grid; gap: 2px; margin-top: 10px; }
+.profile-row { display: grid; grid-template-columns: minmax(0, 1fr) auto auto; align-items: center; gap: 7px; border-top: 1px solid var(--panel-line); padding: 8px 0; }
+.profile-row > div { display: grid; min-width: 0; gap: 2px; }
+.profile-row strong { color: var(--ink-soft); font-size: 10px; }
+.profile-row small { overflow: hidden; color: var(--muted); font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
+.profile-row.drifted strong { color: var(--warning); }
+
+/* ---------- Logs page ---------- */
+
+.runtime-log-list { display: grid; margin-top: 12px; }
+.runtime-log { display: grid; grid-template-columns: 66px minmax(0, 1fr); gap: 8px; border-top: 1px solid var(--panel-line); padding: 7px 1px; }
+.runtime-log span { color: var(--muted-light); font-size: 8px; }
+.runtime-log p { min-width: 0; overflow-wrap: anywhere; margin: 0; color: var(--ink-soft); font: 8px/1.45 ui-monospace, SFMono-Regular, Menlo, monospace; white-space: pre-wrap; }
+.runtime-log.error p { color: var(--danger); }
+
+.job-list { display: grid; max-height: 500px; margin-top: 10px; overflow-y: auto; }
+.job-list > button { display: grid; grid-template-columns: 8px minmax(0, 1fr) 38px; gap: 9px; align-items: center; border: 0; border-top: 1px solid var(--panel-line); padding: 9px 4px; color: inherit; background: transparent; text-align: left; }
+.job-list > button:hover, .job-list > button.active { background: var(--surface-active); }
+.job-list div { display: grid; min-width: 0; gap: 2px; }
+.job-list strong { overflow: hidden; font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
+.job-list small { color: var(--muted-light); font-size: 8px; }
+.job-list b { color: var(--muted); font-size: 8px; text-align: right; }
+.job-status { width: 7px; height: 7px; border-radius: 50%; background: var(--muted-light); }
+.job-status.running { background: var(--warning); box-shadow: 0 0 0 3px var(--warning-soft); }
+.job-status.succeeded { background: var(--success); }
+.job-status.failed, .job-status.interrupted { background: var(--danger); }
+.job-status.cancelling, .job-status.cancelled { background: var(--muted-light); }
+.job-row { display: grid; grid-template-columns: minmax(0, 1fr) minmax(70px, 110px) 38px; gap: 10px; align-items: center; border-top: 1px solid var(--panel-line); padding: 9px 1px; }
+.job-row div { display: grid; min-width: 0; gap: 2px; }
+.job-row strong { overflow: hidden; color: var(--ink-soft); font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
+.job-row small { color: var(--muted-light); font-size: 8px; }
+.job-row progress { width: 100%; height: 5px; accent-color: var(--accent); }
+.job-row > b { color: var(--muted); font-size: 8px; text-align: right; }
+.job-row.completed { grid-template-columns: minmax(0, 1fr) minmax(70px, 110px) 38px 24px; }
+.job-row.completed > button { display: grid; width: 24px; height: 24px; place-content: center; border: 0; border-radius: 6px; padding: 0; color: var(--muted); background: transparent; }
+.job-row.completed > button:hover { color: var(--danger); background: var(--danger-soft); }
+.completed-jobs { border-top: 1px solid var(--panel-line); margin-top: 10px; }
+.completed-jobs > summary { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 9px 1px 5px; color: var(--muted); cursor: pointer; font-size: 9px; list-style: none; }
+.completed-jobs > summary::-webkit-details-marker { display: none; }
+.completed-jobs > summary > span { display: inline-flex; align-items: center; gap: 5px; font-weight: 600; }
+.completed-jobs > summary > span::before { content: "›"; display: inline-block; color: var(--muted-light); transition: transform 140ms ease; }
+.completed-jobs[open] > summary > span::before { transform: rotate(90deg); }
+.completed-jobs > summary b { color: var(--muted-light); font-size: 8px; }
+.completed-jobs > summary button { border: 1px solid var(--panel-line); border-radius: 6px; padding: 4px 7px; color: var(--muted); background: var(--panel-control); font-size: 8px; }
+.completed-jobs > summary button:hover { border-color: var(--line-strong); color: var(--danger); background: var(--danger-soft); }
+.completed-jobs .request-table, .completed-jobs .job-list { margin-top: 3px; }
+
+.job-detail { margin-top: 10px; }
+.job-detail > progress { width: 100%; height: 6px; margin: 15px 0 8px; accent-color: var(--accent); }
+.job-result-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; margin: 8px 0; }
+.job-result-grid > div { display: grid; border-left: 2px solid var(--line-strong); padding-left: 9px; }
+.job-result-grid span { color: var(--muted-light); font-size: 8px; }
+.job-result-grid strong { margin-top: 2px; color: var(--ink-soft); font-size: 11px; }
+.job-detail > pre { max-height: 240px; overflow: auto; border-radius: 7px; padding: 10px; color: var(--ink-soft); background: var(--surface-inset); font: 8px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; }
+.job-error { overflow-wrap: anywhere; border-radius: 7px; margin-top: 10px; padding: 9px; color: var(--danger); background: var(--danger-soft); font-size: 9px; white-space: pre-wrap; }
+.job-actions { display: flex; gap: 7px; flex-wrap: wrap; }
+.job-actions .secondary { border: 1px solid var(--panel-line); border-radius: 7px; padding: 6px 9px; color: var(--ink-soft); background: var(--panel-control); font-size: 9px; }
+.job-actions .secondary:hover { border-color: var(--line-strong); color: var(--ink); background: var(--surface-hover); }
+.job-actions .danger { color: var(--danger); }
+.job-log { max-height: 320px; margin-top: 12px; overflow: auto; border: 1px solid var(--panel-line); border-radius: 8px; background: var(--panel-control); }
+.job-log header { position: sticky; top: 0; padding: 7px 9px; color: var(--muted); background: var(--surface-subtle); font-size: 8px; text-transform: uppercase; }
+.job-log > div { display: grid; grid-template-columns: 70px minmax(0, 1fr); gap: 8px; border-top: 1px solid var(--line-soft); padding: 6px 9px; }
+.job-log time { color: var(--muted-light); font-size: 8px; }
+.job-log code { overflow-wrap: anywhere; color: var(--ink-soft); font: 8px/1.45 ui-monospace, SFMono-Regular, Menlo, monospace; }
+.job-log .error code { color: var(--danger); }
+
+/* ---------- Server page ---------- */
+
 .server-page { display: grid; }
 .server-page > .section-label:first-child { margin-top: 2px; }
 .server-active-notice {
@@ -2500,31 +896,497 @@ select:focus-visible, summary:focus-visible { outline-color: rgb(83 142 144 / 40
 .server-temperature-control { display: flex; align-items: center; gap: 12px; }
 .server-temperature-control input { width: min(20vw, 190px); accent-color: var(--accent); }
 .server-temperature-control strong { width: 42px; color: var(--ink-soft); font: 610 10px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; text-align: right; }
-.server-page-footer {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 14px;
-  margin-top: 18px;
-}
+.server-page-footer { display: flex; align-items: center; justify-content: flex-end; gap: 14px; margin-top: 18px; }
 .server-page-footer > span { color: var(--muted-light); font-size: 10px; }
 .server-page-footer > button.primary { border-color: var(--accent); color: var(--on-accent); background: var(--accent); }
+
+/* ---------- Settings page ---------- */
+
+.settings-page { display: grid; }
+.settings-page > .section-label:first-child { margin-top: 2px; }
+.settings-page-inherited { min-width: 0; border: 0; margin: 0; padding: 0; }
+.settings-page-inherited:disabled { opacity: 0.52; }
+.settings-page-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; }
+.settings-page-section { display: grid; min-width: 0; align-content: start; }
+.settings-page-panel { min-width: 0; }
+.settings-defaults-panel { padding-block: 15px; }
+.settings-defaults-panel input[type="checkbox"],
+.settings-form-panel input[type="checkbox"] { accent-color: var(--accent); }
+.settings-form-panel { display: grid; align-content: start; gap: 15px; }
+.settings-control-block { display: grid; gap: 8px; }
+.settings-control-block > label,
+.settings-range > span,
+.settings-inline-fields label > span,
+.settings-page .saved-presets label > span {
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 610;
+  line-height: 1.45;
+}
+.settings-page .segmented { gap: 4px; }
+.settings-page .segmented button,
+.settings-page button,
+.settings-page .portable-actions label {
+  min-height: 32px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 6px 11px;
+  color: var(--ink-soft);
+  background: var(--panel-control);
+  font-size: 10px;
+  font-weight: 610;
+}
+.settings-page button:hover,
+.settings-page .portable-actions label:hover { border-color: var(--line-strong); background: var(--surface-hover); }
+.settings-page button.primary { border-color: var(--accent); color: var(--on-accent); background: var(--accent); }
+.settings-page textarea,
+.settings-page input:not([type="checkbox"]):not([type="range"]),
+.settings-page select {
+  width: 100%;
+  min-height: 34px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  outline: 0;
+  padding: 7px 9px;
+  color: var(--ink-soft);
+  background: var(--panel-control);
+  font-size: 10px;
+}
+.settings-page textarea { resize: vertical; line-height: 1.5; }
+.settings-page textarea:focus,
+.settings-page input:not([type="checkbox"]):not([type="range"]):focus,
+.settings-page select:focus { border-color: var(--line-strong); box-shadow: 0 0 0 3px var(--accent-soft); }
+.settings-page .saved-presets { gap: 9px; border-top: 1px solid var(--line-soft); margin-top: 0; padding-top: 15px; }
+.settings-page .saved-presets label { display: grid; gap: 6px; margin: 0; }
+.settings-page .saved-presets > small { color: var(--muted-light); font-size: 10px; line-height: 1.5; }
+.settings-page .preset-status { margin: 0; font-size: 10px; }
+.settings-range { display: grid; gap: 8px; }
+.settings-range + .settings-range { border-top: 1px solid var(--line-soft); padding-top: 14px; }
+.settings-range > span { display: flex; justify-content: space-between; gap: 14px; }
+.settings-range output { color: var(--ink-soft); font: 10px/1.45 ui-monospace, SFMono-Regular, Menlo, monospace; }
+.settings-range input { width: 100%; accent-color: var(--accent); }
+.settings-inline-fields { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; border-top: 1px solid var(--line-soft); padding-top: 14px; }
+.settings-inline-fields label { display: grid; gap: 6px; }
+.settings-number-input { width: 112px !important; text-align: right; }
+.settings-context-input { width: 146px !important; }
+.settings-panel-actions { display: flex; justify-content: flex-end; border-top: 1px solid var(--line-soft); margin-top: 2px; padding-top: 14px; }
+.settings-data-panel { padding-block: 15px; }
+.settings-page .portable-actions { flex-wrap: nowrap; }
+.settings-page .portable-actions label { display: grid; place-items: center; margin: 0; cursor: pointer; }
+.settings-page-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 18px; }
+
+.segmented { display: grid; grid-template-columns: repeat(3, 1fr); gap: 3px; }
+.segmented button { border: 1px solid transparent; border-radius: 7px; padding: 6px 2px; color: var(--muted); background: transparent; font-size: 9px; }
+.segmented button[aria-pressed="true"] { border-color: var(--accent-border); color: var(--accent-ink); background: var(--accent-soft); }
+
+.saved-presets { display: grid; gap: 7px; border-top: 1px solid var(--line-soft); margin-top: 11px; padding-top: 11px; }
+.saved-presets label { margin: 0; }
+.saved-presets > small { color: var(--muted-light); font-size: 8px; line-height: 1.45; }
+.preset-save-row { display: grid; grid-template-columns: minmax(0, 1fr) auto 30px; gap: 5px; }
+.preset-save-row input { min-width: 0; }
+.preset-save-row button { padding-inline: 10px; white-space: nowrap; }
+.preset-save-row .preset-delete { display: grid; width: 30px; place-items: center; padding: 0; color: var(--danger); }
+.preset-status { margin: 0; color: var(--success); font-size: 8px; }
+.preset-status.error { color: var(--danger); }
+.portable-actions { display: flex; gap: 6px; }
+.portable-actions button, .portable-actions label { display: grid; place-items: center; border: 1px solid var(--line); border-radius: 7px; margin: 0; padding: 6px 10px; color: var(--muted); background: var(--surface-subtle); font-size: 9px; cursor: pointer; }
+.portable-actions input { display: none; }
+
+/* ---------- Lab pages ---------- */
+
+.hub-panel { margin-bottom: 10px; }
+.hub-search { display: grid; grid-template-columns: auto minmax(180px, 1fr) auto; gap: 7px; margin-top: 12px; }
+.hub-search input, .hub-search select, .hub-search button, .hub-detail button { min-width: 0; border: 1px solid var(--panel-line); border-radius: 7px; padding: 7px 9px; color: var(--ink); background: var(--panel-control); font-size: 9px; }
+.hub-search button:hover, .hub-detail button:hover { border-color: var(--line-strong); background: var(--surface-hover); }
+.hub-results { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 4px; margin-top: 10px; }
+.hub-results > button { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 8px; border: 1px solid var(--panel-line); border-radius: 7px; padding: 8px; color: inherit; background: var(--panel-control); text-align: left; }
+.hub-results > button.active, .hub-results > button:hover { border-color: var(--accent-border); background: var(--accent-soft); }
+.hub-results div, .hub-detail > div { display: grid; min-width: 0; gap: 2px; }
+.hub-results strong, .hub-detail strong { overflow: hidden; font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
+.hub-results small, .hub-detail small, .hub-results span { color: var(--muted); font-size: 8px; }
+.hub-detail { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 10px; border-top: 1px solid var(--panel-line); margin-top: 10px; padding-top: 10px; }
+.hub-detail button { display: flex; align-items: center; gap: 5px; }
+
+.node-form { display: grid; grid-template-columns: minmax(100px, .4fr) minmax(180px, 1fr) minmax(160px, .8fr) auto; gap: 7px; margin-top: 12px; }
+.node-form input, .node-form button { min-width: 0; border: 1px solid var(--panel-line); border-radius: 7px; padding: 7px 9px; color: var(--ink-soft); background: var(--panel-control); font-size: 9px; }
+.node-list { display: grid; margin-top: 10px; }
+.node-list > div { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 8px; border-top: 1px solid var(--panel-line); padding: 8px 0; }
+.node-list > div > div { display: grid; min-width: 0; gap: 2px; }
+.node-list strong { color: var(--ink-soft); font-size: 10px; }
+.node-list small { overflow: hidden; color: var(--muted); font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
+.node-list button { border: 0; color: var(--muted); background: transparent; font-size: 9px; }
+
+.mcp-panel { margin-top: 10px; }
+.cluster-panel { margin-top: 10px; }
+.mcp-form { display: grid; grid-template-columns: minmax(110px, .3fr) auto minmax(240px, 1fr) auto; gap: 7px; margin-top: 12px; }
+.mcp-form input, .mcp-form select { min-width: 0; border: 1px solid var(--panel-line); border-radius: 7px; padding: 7px 9px; color: var(--ink-soft); background: var(--panel-control); font-size: 10px; }
+.mcp-form button { min-width: 64px; border: 1px solid var(--accent); border-radius: 7px; padding: 7px 11px; color: var(--on-accent); background: var(--accent); font-size: 9px; font-weight: 620; }
+.mcp-form button:hover { border-color: var(--accent-hover); background: var(--accent-hover); }
+.mcp-server-list { display: grid; gap: 4px; margin-top: 10px; }
+.mcp-server { display: grid; grid-template-columns: auto minmax(0, 1fr) auto auto; align-items: center; gap: 8px; border-top: 1px solid var(--panel-line); padding: 8px 0; }
+.mcp-server div { display: grid; min-width: 0; gap: 2px; }
+.mcp-server strong { color: var(--ink-soft); font-size: 10px; }
+.mcp-server small { overflow: hidden; color: var(--muted); font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
+.mcp-server button { border: 0; color: var(--muted); background: transparent; font-size: 9px; }
+
+.panel-action { width: 100%; border: 1px solid var(--line); border-radius: 9px; margin-top: 7px; padding: 8px 10px; color: var(--muted); background: var(--panel-control); font-size: 11px; }
+.panel-action:hover { border-color: var(--line-strong); color: var(--ink); background: var(--surface-hover); }
+.panel-action.danger { color: var(--danger); }
+
+.evaluation-list, .dataset-list, .lineage-list { display: grid; gap: 3px; margin-top: 11px; }
+.evaluation-list > label { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 8px; border-top: 1px solid var(--panel-line); padding: 8px 1px; }
+.evaluation-list div, .dataset-list div > div, .lineage-list summary > div { display: grid; min-width: 0; gap: 2px; }
+.evaluation-list strong, .dataset-list strong, .lineage-list strong { overflow: hidden; font-size: 9px; text-overflow: ellipsis; white-space: nowrap; }
+.evaluation-list small, .dataset-list small, .lineage-list small, .evaluation-list > label > span { color: var(--muted); font-size: 8px; }
+.comparison-table { margin-top: 10px; overflow-x: auto; }
+.comparison-table header, .comparison-table > div { display: grid; grid-template-columns: minmax(120px, 1fr) repeat(4, minmax(90px, auto)); gap: 8px; border-top: 1px solid var(--panel-line); padding: 7px 1px; font-size: 8px; }
+.comparison-table header { color: var(--muted); }
+.comparison-table small { color: var(--accent); }
+.dataset-form { display: grid; grid-template-columns: minmax(90px, .7fr) auto minmax(150px, 1fr) auto; gap: 6px; margin-top: 11px; }
+.dataset-form input, .dataset-form select, .dataset-form button { min-width: 0; border: 1px solid var(--panel-line); border-radius: 7px; padding: 7px 8px; color: var(--ink-soft); background: var(--panel-control); font-size: 9px; }
+.dataset-list > div { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; border-top: 1px solid var(--panel-line); padding: 8px 1px; }
+.dataset-list button { border: 0; color: var(--muted); background: transparent; }
+.lineage-panel { margin-bottom: 10px; }
+.lineage-list details { border-top: 1px solid var(--panel-line); }
+.lineage-list summary { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 8px; padding: 8px 1px; cursor: pointer; }
+.lineage-list summary > span { color: var(--muted); font-size: 8px; }
+.lineage-list dl { margin: 0 10px; }
+.lineage-list pre { max-height: 180px; overflow: auto; border-radius: 7px; padding: 9px; background: var(--surface-subtle); font: 8px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; }
+
+.imatrix-panel { margin-bottom: 10px; }
+.imatrix-actions { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 10px; }
+.imatrix-actions button { display: inline-flex; height: 25px; align-items: center; gap: 4px; border: 1px solid var(--panel-line); border-radius: 6px; padding: 0 7px; color: var(--muted); background: var(--panel-control); font-size: 8px; font-weight: 550; line-height: 1; }
+.imatrix-actions button:hover { border-color: var(--line-strong); color: var(--ink); background: var(--surface-hover); }
+.imatrix-list { display: grid; gap: 5px; margin-top: 9px; }
+.imatrix-list button { display: flex; align-items: center; justify-content: space-between; gap: 12px; width: 100%; padding: 8px 9px; border: 1px solid var(--panel-line); border-radius: 7px; background: var(--panel-control); color: var(--ink); text-align: left; }
+.imatrix-list button:hover { border-color: var(--accent-border); }
+.imatrix-list button div { min-width: 0; display: grid; gap: 2px; }
+.imatrix-list strong, .imatrix-list small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.imatrix-list small { color: var(--muted); font-size: 8px; }
+.imatrix-list span { flex: 0 0 auto; color: var(--accent); font-size: 8px; font-weight: 650; }
+
+.job-builder label { display: grid; gap: 5px; margin-top: 10px; color: var(--muted); font-size: 9px; }
+.job-builder label > span { color: var(--ink-soft); font-weight: 600; }
+.job-builder label > small { color: var(--muted-light); font-size: 8px; line-height: 1.45; }
+.job-builder input:not([type="checkbox"]), .job-builder select { width: 100%; border: 1px solid var(--panel-line); border-radius: 7px; outline: 0; padding: 7px 8px; color: var(--ink); background: var(--panel-control); font-size: 9px; }
+.job-builder input:focus, .job-builder select:focus { border-color: var(--accent-border); box-shadow: 0 0 0 2px var(--accent-soft); }
+.job-submit { display: flex; justify-content: flex-end; border-top: 1px solid var(--panel-line); margin-top: 16px; padding-top: 12px; }
+.job-run {
+  display: inline-flex;
+  min-width: 86px;
+  height: 32px;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  border: 1px solid var(--accent);
+  border-radius: 9px;
+  padding: 0 15px;
+  color: var(--on-accent);
+  background: var(--accent);
+  font-size: 10px;
+  font-weight: 650;
+  box-shadow: var(--shadow-sm);
+}
+.job-run:hover { border-color: var(--accent-hover); background: var(--accent-hover); transform: translateY(-1px); }
+.job-run:active { transform: translateY(0); box-shadow: none; }
+
+/* ---------- Chat ---------- */
+
+.chat-view {
+  display: grid;
+  min-height: 0;
+  grid-template-rows: auto minmax(0, 1fr) auto auto;
+  background: var(--canvas);
+}
+
+.chat-screen-header {
+  display: flex;
+  min-width: 0;
+  min-height: 70px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  border-bottom: 1px solid var(--line);
+  padding: 14px 24px;
+  background: var(--surface-overlay);
+}
+.chat-screen-title { min-width: 0; }
+.chat-screen-title h1 {
+  overflow: hidden;
+  margin: 0;
+  max-width: none;
+  color: var(--ink-strong);
+  font-size: 20px;
+  font-weight: 660;
+  letter-spacing: -0.025em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.chat-screen-actions { display: flex; min-width: 0; align-items: center; gap: 10px; }
+.chat-model-summary { display: grid; min-width: 0; gap: 2px; text-align: right; }
+.chat-model-summary strong {
+  overflow: hidden;
+  max-width: min(27vw, 350px);
+  color: var(--ink-soft);
+  font-size: 11px;
+  font-weight: 630;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.chat-model-summary small { color: var(--muted); font-size: 8px; white-space: nowrap; }
+.chat-icon-button {
+  display: grid;
+  width: 31px;
+  height: 31px;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  padding: 0;
+  color: var(--muted);
+  background: transparent;
+}
+.chat-icon-button:hover { border-color: var(--line); color: var(--danger); background: var(--surface-subtle); }
+
+.message-scroller { overflow-y: auto; }
+.message-scroller { min-height: 0; overscroll-behavior: contain; }
+.message-list { width: min(850px, 100%); min-height: 100%; margin: 0 auto; padding: 24px 24px 24px; }
+.welcome { display: grid; place-items: center; max-width: 610px; margin: 15vh auto 0; text-align: center; }
+.welcome > .ui-icon { margin-bottom: 16px; color: var(--muted); stroke-width: 1.25; }
+.welcome h1, .welcome h2 { margin: 0; color: var(--ink-strong); font-size: 25px; font-weight: 660; letter-spacing: -0.025em; }
+.welcome p { max-width: 510px; margin: 11px 0 0; color: var(--muted); font-size: 13px; line-height: 1.55; }
+.open-model-primary {
+  display: inline-flex;
+  min-height: 42px;
+  align-items: center;
+  gap: 7px;
+  border: 1px solid var(--accent);
+  border-radius: 11px;
+  margin-top: 19px;
+  padding: 9px 16px;
+  color: var(--on-accent);
+  background: var(--accent);
+  font-size: 13px;
+  font-weight: 620;
+  box-shadow: none;
+}
+.open-model-primary:hover { border-color: var(--accent-hover); background: var(--accent-hover); }
+
+.message { display: grid; grid-template-columns: 30px minmax(0, 1fr); gap: 12px; margin-bottom: 18px; }
+.message-user { grid-template-columns: minmax(0, 1fr); padding-left: 90px; }
+.message-user .message-avatar { display: none; }
+.message-avatar { display: grid; width: 30px; height: 30px; place-items: center; border: 0; border-radius: 8px; color: var(--muted); background: transparent; box-shadow: none; }
+.message-avatar img { width: 30px; height: 30px; }
+.message-body { min-width: 0; }
+.message-assistant .message-body {
+  width: fit-content;
+  max-width: 690px;
+  border-radius: 12px;
+  padding: 15px;
+  background: rgb(127 127 127 / 6%);
+}
+.message-user .message-body { grid-column: 1; grid-row: 1; justify-self: end; width: fit-content; max-width: 690px; }
+.message-user .message-content { border: 0; border-radius: 12px; padding: 15px; background: var(--surface-user); }
+.message-meta { display: flex; align-items: baseline; gap: 8px; margin-bottom: 8px; }
+.message-meta strong { color: var(--ink-soft); font-size: 11px; font-weight: 650; }
+.message-meta span { color: var(--muted-light); font-size: 9px; }
+.message-actions { display: flex; gap: 2px; margin-top: 9px; opacity: 0; transition: opacity 120ms; }
+.message-user .message-actions { justify-content: flex-end; }
+.message:hover .message-actions, .message:focus-within .message-actions { opacity: 1; }
+.message-actions button { border: 0; border-radius: 7px; padding: 4px 7px; color: var(--muted-light); background: transparent; font-size: 10px; }
+.message-actions button:hover { color: var(--ink); background: var(--accent-soft); }
+.live-message .message-avatar { box-shadow: none; }
+
+.response-metrics { margin-top: 7px; color: var(--muted-light); font-size: 10px; }
+.response-metrics summary { display: flex; width: fit-content; cursor: pointer; gap: 8px; list-style: none; }
+.response-metrics summary::-webkit-details-marker { display: none; }
+.response-metrics summary span + span { border-left: 1px solid var(--line); padding-left: 8px; }
+.response-metrics > div { display: flex; flex-wrap: wrap; gap: 5px 10px; margin-top: 6px; }
+
+.rich-text { color: var(--ink); font-size: 13.5px; line-height: 1.62; overflow-wrap: anywhere; }
+.rich-text > :first-child { margin-top: 0; }
+.rich-text > :last-child { margin-bottom: 0; }
+.rich-text p, .rich-text ul, .rich-text ol, .rich-text pre, .rich-text blockquote { margin: 0.68em 0; }
+.rich-text ul, .rich-text ol { padding-left: 1.7em; }
+.rich-text li + li { margin-top: 0.18em; }
+.rich-text h1, .rich-text h2, .rich-text h3 { margin: 1.15em 0 0.42em; color: var(--ink-strong); font-weight: 670; letter-spacing: -0.015em; }
+.rich-text h1 { font-size: 1.48em; }
+.rich-text h2 { font-size: 1.26em; }
+.rich-text h3 { font-size: 1.1em; }
+.rich-text code { border: 1px solid var(--line); border-radius: 5px; padding: 0.1em 0.32em; color: var(--accent-ink); background: var(--surface-subtle); font-family: "SFMono-Regular", "Cascadia Code", Consolas, monospace; font-size: 0.88em; }
+.rich-text pre { position: relative; overflow-x: auto; border: 1px solid var(--line); border-radius: 12px; padding: 30px 14px 14px; color: var(--ink); background: var(--surface-inset); }
+.rich-text pre code { border: 0; padding: 0; color: inherit; background: transparent; }
+.code-copy { position: absolute; top: 6px; right: 7px; border: 1px solid var(--line-strong); border-radius: 6px; padding: 3px 7px; color: var(--muted); background: var(--surface-subtle); font-size: 8px; }
+.code-copy:hover { color: var(--ink); background: var(--surface-hover); }
+.rich-text blockquote { border-left: 2px solid var(--accent); margin-left: 0; padding-left: 12px; color: var(--muted); }
+.rich-text a { color: var(--accent-ink); text-underline-offset: 2px; }
+.rich-text table { width: 100%; border-collapse: separate; border-spacing: 0; overflow: hidden; border: 1px solid var(--line); border-radius: 8px; }
+.rich-text th, .rich-text td { border-right: 1px solid var(--line); border-bottom: 1px solid var(--line); padding: 7px 9px; text-align: left; }
+.rich-text tr:last-child td { border-bottom: 0; }
+.rich-text th:last-child, .rich-text td:last-child { border-right: 0; }
+.rich-text th { background: var(--surface-subtle); font-weight: 650; }
+
+.reasoning { border: 1px solid var(--line-soft); border-radius: 11px; margin: 3px 0 10px; padding: 8px 10px; color: var(--muted); background: var(--surface-subtle); }
+.reasoning summary { cursor: pointer; color: var(--muted); font-size: 10px; font-weight: 620; }
+.reasoning .rich-text { margin-top: 8px; color: var(--muted); font-size: 11.5px; }
+
+.tool-call { overflow-x: auto; border: 1px solid var(--line); border-radius: 9px; padding: 10px; color: var(--ink-soft); background: var(--surface-inset); font-size: 10px; }
+.tool-call pre { margin: 0; color: inherit; white-space: pre-wrap; }
+.tool-confirm { margin-top: 6px; }
+.tool-confirm button { border: 1px solid var(--accent-border); border-radius: 7px; padding: 5px 8px; color: var(--accent-ink); background: var(--accent-soft); font-size: 9px; }
+
+.message-editor { display: grid; gap: 7px; }
+.message-editor textarea { width: 100%; min-height: 90px; resize: vertical; border: 1px solid var(--line); border-radius: 8px; outline: none; padding: 9px; color: var(--ink); background: var(--surface-control); }
+.message-editor > div { display: flex; justify-content: flex-end; gap: 6px; }
+.message-editor button, .studio-dialog button { border: 1px solid var(--line); border-radius: 7px; padding: 7px 10px; color: var(--ink-soft); background: var(--surface); }
+.message-editor button:hover, .studio-dialog button:hover { border-color: var(--line-strong); background: var(--surface-subtle); }
+
+.message-media { display: block; max-width: min(560px, 100%); max-height: 440px; border: 1px solid var(--line); border-radius: 10px; margin: 4px 0 10px; background: var(--surface-subtle); object-fit: contain; }
+.media-image { width: auto; }
+.media-video { width: min(560px, 100%); }
+.message-audio { width: min(420px, 100%); height: 34px; margin-top: 9px; }
+.message-media-status { display: block; width: min(360px, 100%); border: 1px solid var(--line); border-radius: 9px; margin: 4px 0 10px; padding: 10px; color: var(--muted); background: var(--surface-subtle); font-size: 9px; }
+.message-document { display: flex; width: min(360px, 100%); align-items: center; gap: 9px; border: 1px solid var(--line); border-radius: 9px; margin: 5px 0; padding: 8px; color: inherit; background: var(--surface); font: inherit; text-align: left; cursor: pointer; }
+.message-document:disabled { cursor: progress; opacity: 0.7; }
+.message-document > span { display: grid; width: 31px; height: 31px; place-items: center; border-radius: 7px; color: var(--accent); background: var(--accent-soft); font-size: 8px; font-weight: 700; }
+.message-document div { display: grid; min-width: 0; gap: 2px; }
+.message-document strong { overflow: hidden; color: var(--ink); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
+.message-document small { color: var(--muted-light); font-size: 8px; }
+.thinking { display: flex; gap: 4px; padding: 10px 0; }
+.thinking i { width: 5px; height: 5px; border-radius: 50%; background: var(--accent); animation: bounce 1s infinite ease-in-out; }
+.thinking i:nth-child(2) { animation-delay: 120ms; }
+.thinking i:nth-child(3) { animation-delay: 240ms; }
+@keyframes bounce { 50% { opacity: 0.35; transform: translateY(-3px); } }
+
+.error-banner { display: flex; width: min(812px, calc(100% - 40px)); max-height: 148px; align-items: flex-start; justify-content: space-between; gap: 10px; overflow: auto; border: 1px solid var(--danger); border-radius: 8px; margin: 0 auto 8px; padding: 8px 10px; color: var(--danger); background: var(--danger-soft); font-size: 10px; }
+.error-banner span { min-width: 0; overflow-wrap: anywhere; white-space: pre-wrap; }
+.error-banner button { border: 0; color: inherit; background: transparent; }
+
+.composer-region {
+  width: 100%;
+  max-width: none;
+  border-top: 1px solid var(--line-soft);
+  padding: 13px max(22px, calc((100% - 850px) / 2)) 10px;
+  background: var(--surface-overlay);
+  backdrop-filter: blur(20px) saturate(1.1);
+}
+.composer-region > .composer,
+.composer-region > .voice-component-banner,
+.composer-region > p { width: min(850px, 100%); margin-inline: auto; }
+.composer-region > p { margin-block: 6px 0; color: var(--muted-light); font-size: 8px; text-align: center; }
+.voice-component-banner { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 7px 12px; border: 1px solid var(--accent-border); border-radius: 10px; margin-bottom: 8px; padding: 9px 10px; color: var(--accent-ink); background: var(--accent-soft); }
+.voice-component-banner > div { display: grid; min-width: 0; gap: 2px; }
+.voice-component-banner strong { font-size: 10px; }
+.voice-component-banner span { overflow: hidden; color: var(--muted); font-size: 8px; text-overflow: ellipsis; white-space: nowrap; }
+.voice-component-banner progress { width: 100%; height: 4px; grid-column: 1 / -1; accent-color: var(--accent); }
+.voice-component-banner button { grid-column: 2; grid-row: 1; border: 1px solid var(--accent-border); border-radius: 7px; padding: 6px 9px; color: var(--on-accent); background: var(--accent); font-size: 9px; font-weight: 650; }
+.voice-component-banner button:disabled { cursor: progress; opacity: 0.65; }
+.composer { overflow: hidden; border: 1px solid var(--line); border-radius: 12px; background: var(--surface); box-shadow: none; }
+.composer:focus-within { border-color: var(--line-strong); box-shadow: 0 0 0 3px var(--accent-soft); }
+.composer textarea { display: block; width: 100%; min-height: 48px; max-height: 180px; resize: none; border: 0; outline: 0; padding: 12px 13px 5px; color: var(--ink); background: transparent; font-size: 13px; line-height: 1.5; }
+.composer textarea::placeholder { color: var(--muted-light); }
+.composer-toolbar { display: flex; min-height: 42px; align-items: center; gap: 4px; padding: 5px 7px 7px; }
+.composer-toolbar > button, .composer-toolbar select { display: flex; height: 31px; align-items: center; justify-content: center; gap: 5px; border: 1px solid var(--line); border-radius: 8px; padding: 0 7px; color: var(--muted); background: var(--surface-subtle); font-size: 10px; }
+.composer-toolbar > button:hover, .composer-toolbar select:hover { border-color: var(--line-strong); color: var(--ink); background: var(--surface-hover); }
+.composer-toolbar > button[aria-pressed="true"] { border-color: var(--accent-border); color: var(--ink); background: var(--accent-soft); }
+.composer-toolbar .voice-button { position: relative; width: 28px; padding: 0; border-radius: 50%; }
+.voice-button span { position: absolute; inset: 8px; border-radius: 50%; background: var(--accent); transform: scale(calc(0.82 + var(--voice-level) * 0.38)); box-shadow: 0 0 calc(4px + var(--voice-level) * 9px) var(--accent-soft); }
+.composer-hint { margin-left: auto; color: var(--muted-light); font-size: 9px; }
+.composer-toolbar .send-button { width: 32px; border-color: var(--accent); border-radius: 50%; padding: 0; color: var(--on-accent); background: var(--accent); }
+.composer-toolbar .send-button:hover { border-color: var(--accent-hover); background: var(--accent-hover); }
+.composer-toolbar .send-button.stop { border-color: var(--danger); color: #fff; background: var(--danger); }
+.attachment-tray { display: flex; gap: 7px; overflow-x: auto; padding: 9px 9px 0; }
+.attachment-chip { position: relative; display: grid; min-width: 178px; grid-template-columns: 36px minmax(0, 1fr) 20px; align-items: center; gap: 7px; border: 1px solid var(--line); border-radius: 8px; padding: 5px; background: var(--surface-subtle); }
+.attachment-chip > img, .attachment-chip > video, .attachment-chip > span { display: grid; width: 36px; height: 36px; place-items: center; border-radius: 6px; background: var(--surface-hover); object-fit: cover; }
+.attachment-chip div { display: grid; min-width: 0; }
+.attachment-chip strong { overflow: hidden; font-size: 9px; font-weight: 620; text-overflow: ellipsis; white-space: nowrap; }
+.attachment-chip small { color: var(--muted); font-size: 8px; }
+.attachment-chip button { border: 0; color: var(--muted); background: transparent; }
+
+/* ---------- Dialogs ---------- */
+
+.dialog-backdrop { position: fixed; inset: 0; z-index: 30; display: grid; place-items: center; padding: 20px; background: rgb(21 23 23 / 34%); backdrop-filter: blur(3px); }
+.studio-dialog { display: grid; width: min(500px, 100%); max-height: 90vh; overflow-y: auto; border: 1px solid var(--line); border-radius: 14px; color: var(--ink); background: var(--canvas); box-shadow: var(--shadow-md); }
+.studio-dialog header { display: flex; align-items: flex-start; justify-content: space-between; padding: 22px 22px 14px; }
+.studio-dialog h2 { margin: 3px 0 0; font-size: 21px; font-weight: 650; letter-spacing: -0.015em; }
+.studio-dialog header > button { width: 28px; height: 28px; border: 0; padding: 0; color: var(--muted); background: transparent; font-size: 20px; }
+.studio-dialog header p { margin: 4px 0 0; color: var(--muted); font-size: 9px; }
+.studio-dialog label { display: grid; gap: 5px; margin: 9px 0; color: var(--muted); font-size: 11px; }
+.studio-dialog label > span { display: flex; justify-content: space-between; }
+.studio-dialog input { width: 100%; min-height: 36px; border: 1px solid var(--line); border-radius: 9px; outline: 0; padding: 8px 10px; color: var(--ink); background: var(--surface-control); }
+.studio-dialog input:focus { border-color: var(--line-strong); box-shadow: 0 0 0 3px var(--accent-soft); }
+.studio-dialog > .segmented, .studio-dialog > label, .dialog-status { margin-inline: 18px; }
+.studio-dialog > .segmented { border-radius: 8px; padding: 3px; background: var(--surface-subtle); }
+.dialog-status { display: flex; align-items: center; gap: 7px; border: 1px solid var(--line); border-radius: 8px; margin-block: 10px; padding: 8px 9px; color: var(--muted); background: var(--surface); font-size: 9px; }
+.dialog-status span { width: 7px; height: 7px; flex: 0 0 auto; border-radius: 50%; }
+.dialog-status span.online { background: var(--success); }
+.dialog-status span.offline { background: var(--danger); }
+.studio-dialog footer { display: flex; justify-content: flex-end; gap: 7px; border-top: 1px solid var(--line); padding: 11px 17px; background: var(--surface-overlay); }
+.studio-dialog footer .primary { border-color: var(--accent); background: var(--accent); }
+
+.model-browser-dialog { width: min(620px, 100%); grid-template-rows: auto auto minmax(220px, 52vh) auto; overflow: hidden; }
+.model-browser-location { display: grid; grid-template-columns: auto minmax(0, 1fr) auto auto; align-items: center; gap: 7px; border-block: 1px solid var(--line-soft); padding: 9px 18px; color: var(--muted); background: var(--surface-overlay); font-size: 9px; }
+.model-browser-location input { min-width: 0; height: 30px; border-color: var(--line-soft); border-radius: 7px; padding-inline: 10px; color: var(--ink); background: var(--surface); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 9px; }
+.model-browser-location button { min-height: 30px; padding: 6px 10px; }
+.model-browser-location span { color: var(--accent-ink); }
+.model-browser-list { min-height: 0; overflow-y: auto; padding: 7px 10px; }
+.model-browser-list > button { display: grid; width: 100%; grid-template-columns: 18px minmax(0, 1fr) auto; align-items: center; gap: 8px; border: 0; padding: 9px 10px; color: var(--ink-soft); background: transparent; text-align: left; }
+.model-browser-list > button:hover { border-color: transparent; background: var(--surface-subtle); }
+.model-browser-list > button span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.model-browser-list > button b { color: var(--muted); font-size: 8px; font-weight: 600; }
+.model-browser-list > p { margin: 28px 12px; color: var(--muted); text-align: center; font-size: 9px; }
+
+/* ---------- Fatal error ---------- */
+
+.fatal-error { min-height: 100vh; display: grid; place-items: center; padding: 32px; background: var(--canvas); color: var(--ink); }
+.fatal-error section { width: min(640px, 100%); padding: 28px; border: 1px solid var(--line); border-radius: 16px; background: var(--surface); box-shadow: var(--shadow-md); }
+.fatal-error h1 { margin: 8px 0 12px; font-size: 24px; }
+.fatal-error p { color: var(--muted); line-height: 1.6; }
+.fatal-error pre { overflow: auto; margin: 18px 0; padding: 14px; border-radius: 9px; background: var(--surface-subtle); white-space: pre-wrap; word-break: break-word; }
+
+/* ---------- Responsive ---------- */
+
+@container (max-width: 620px) {
+  .metric-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .cache-stats { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .node-form, .mcp-form, .dataset-form { grid-template-columns: 1fr 1fr; }
+}
+
+@container (max-width: 390px) {
+  .metric-grid, .cache-stats { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .node-form, .mcp-form, .dataset-form, .profile-create { grid-template-columns: 1fr; }
+  .panel-heading p { display: none; }
+}
 
 @media (max-width: 1080px) {
   .metric-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
   .server-tools-grid { grid-template-columns: 1fr; }
 }
 
+@media (max-width: 980px) {
+  .app-shell { grid-template-columns: 220px minmax(0, 1fr); }
+}
+
+@media (max-width: 860px) {
+  .app-shell { grid-template-columns: 220px minmax(0, 1fr); }
+  .tm-panel.runtime-hero { grid-template-columns: 46px minmax(0, 1fr); }
+  .model-monogram { width: 46px; height: 46px; font-size: 24px; }
+  .runtime-hero-actions { grid-column: 1 / -1; }
+  .panel-deck { grid-template-columns: 1fr; }
+  .panel-deck .panel-shell { grid-column: 1; transform: none; }
+  .panel-deck .panel-drag { display: none; }
+}
+
 @media (max-width: 760px) {
   .screen-header { min-height: 0; align-items: flex-start; }
   .screen-header h1 { font-size: 24px; }
   .screen-header p { max-width: 70vw; }
-  .metric-grid,
-  .logs-grid { grid-template-columns: 1fr; }
+  .chat-screen-header { align-items: flex-start; padding: 14px; }
+  .chat-model-summary { display: none; }
+  .chat-screen-title h1 { max-width: 48vw; font-size: 17px; }
+  .runtime-status-pill { display: none; }
+  .metric-grid, .logs-grid { grid-template-columns: 1fr; }
   .logs-grid > .runtime-log-panel { grid-column: 1; }
-  .tm-panel.runtime-hero { grid-template-columns: 46px minmax(0, 1fr); }
-  .model-monogram { width: 46px; height: 46px; font-size: 24px; }
-  .runtime-hero-actions { grid-column: 1 / -1; }
   .overview-footer-grid { grid-template-columns: 1fr; }
   .settings-page-grid { grid-template-columns: 1fr; }
   .setting-row { align-items: flex-start; }
@@ -2532,4 +1394,54 @@ select:focus-visible, summary:focus-visible { outline-color: rgb(83 142 144 / 40
   .server-page .setting-row-trailing { max-width: 58%; }
   .server-row-actions { flex-wrap: wrap; }
   .server-prompt-input, .server-wide-input { width: 42vw; }
+  .panel-deck.page-dashboard-logs { grid-template-columns: 1fr; }
+  .panel-deck.page-dashboard-logs > [data-panel-id] { grid-column: 1; }
+  .model-catalog-panel .model-list { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 680px) {
+  body { overflow: hidden; }
+  .app-shell { display: block; height: 100vh; height: 100dvh; overflow: hidden; }
+  .sidebar {
+    position: fixed;
+    inset: 0 auto 0 0;
+    z-index: 31;
+    width: min(300px, 88vw);
+    border-right: 1px solid var(--sidebar-line);
+    box-shadow: 18px 0 48px rgb(0 0 0 / 22%);
+    transform: translateX(-104%);
+    transition: transform 180ms ease;
+  }
+  .sidebar.open { transform: translateX(0); }
+  .mobile-scrim {
+    position: fixed;
+    inset: 0;
+    z-index: 30;
+    display: block;
+    border: 0;
+    padding: 0;
+    pointer-events: none;
+    opacity: 0;
+    background: rgb(12 14 14 / 38%);
+    backdrop-filter: blur(2px);
+    transition: opacity 180ms ease;
+  }
+  .mobile-scrim.open { pointer-events: auto; opacity: 1; }
+  .message-list { padding: 28px 14px 20px; }
+  .message { grid-template-columns: 28px minmax(0, 1fr); gap: 8px; margin-bottom: 19px; }
+  .message-avatar { width: 27px; height: 27px; }
+  .message-user { padding-left: 32px; }
+  .message-user .message-body { width: fit-content; max-width: min(100%, 560px); }
+  .message-actions { opacity: 1; }
+  .composer-region { padding-inline: 10px; }
+  .composer-hint { display: none; }
+  .composer-toolbar { flex-wrap: wrap; }
+  .composer-toolbar .send-button { margin-left: auto; }
+  .dashboard-view, .lab-view { padding: 26px 14px 42px; }
+  .tm-panel.runtime-hero { padding: 15px; }
+}
+
+@media (max-width: 420px) {
+  .metric-grid { grid-template-columns: 1fr; }
+  .runtime-hero-actions button { flex: 1; justify-content: center; }
 }

--- a/MFQStudio/src/styles.css
+++ b/MFQStudio/src/styles.css
@@ -154,6 +154,7 @@ html, body, #root { min-width: 320px; min-height: 100%; margin: 0; }
 body { overflow: hidden; }
 button, input, textarea, select { font: inherit; }
 button { cursor: pointer; }
+button:not(:disabled):active { opacity: 0.8; }
 button:disabled { cursor: not-allowed; opacity: 0.45; }
 button, input, textarea, select {
   transition: border-color 130ms ease, background-color 130ms ease, color 130ms ease,
@@ -735,6 +736,7 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
   background: transparent;
 }
 .overview-panel-title > button:hover { color: var(--ink); background: var(--surface-hover); }
+.overview-panel-title > button.copied { color: var(--success); }
 .overview-panel-title > span { margin-left: auto; color: var(--muted); font: 11px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; }
 .overview-endpoint-panel > code {
   overflow: hidden;

--- a/MFQStudio/src/styles.css
+++ b/MFQStudio/src/styles.css
@@ -18,8 +18,8 @@
   --ink: #202122;
   --ink-strong: #111213;
   --ink-soft: #454748;
-  --muted: #737678;
-  --muted-light: #999c9e;
+  --muted: #5f6264;
+  --muted-light: #6c6f71;
   --line: rgb(32 34 35 / 12%);
   --line-strong: rgb(32 34 35 / 18%);
   --line-soft: rgb(32 34 35 / 8%);
@@ -63,7 +63,7 @@
   --ink-strong: #ffffff;
   --ink-soft: #ced0d0;
   --muted: #999d9e;
-  --muted-light: #6f7475;
+  --muted-light: #8d9293;
   --line: rgb(240 243 243 / 12%);
   --line-strong: rgb(240 243 243 / 18%);
   --line-soft: rgb(240 243 243 / 7%);
@@ -108,7 +108,7 @@
     --ink-strong: #ffffff;
     --ink-soft: #ced0d0;
     --muted: #999d9e;
-    --muted-light: #6f7475;
+    --muted-light: #8d9293;
     --line: rgb(240 243 243 / 12%);
     --line-strong: rgb(240 243 243 / 18%);
     --line-soft: rgb(240 243 243 / 7%);
@@ -251,7 +251,7 @@ select:focus-visible, summary:focus-visible {
   text-align: left;
 }
 .sectioned-nav button:hover { color: var(--ink); background: var(--sidebar-hover); }
-.sectioned-nav button.active { color: var(--on-accent); background: var(--accent); }
+.sectioned-nav button.active { color: var(--on-accent); background: var(--accent); font-weight: 700; }
 .sectioned-nav button.active .ui-icon { color: currentColor; }
 .sectioned-nav button > span {
   min-width: 22px;
@@ -260,7 +260,7 @@ select:focus-visible, summary:focus-visible {
   padding: 1px 6px;
   color: inherit;
   background: rgb(127 127 127 / 17%);
-  font-size: 9.5px;
+  font-size: 10px;
   text-align: center;
 }
 
@@ -402,7 +402,7 @@ select:focus-visible, summary:focus-visible {
 }
 .panel-heading-actions button:hover { border-color: var(--line-strong); color: var(--ink); background: var(--surface-hover); }
 
-button.primary { border-color: var(--accent); color: var(--on-accent); background: var(--accent); }
+button.primary { border-color: var(--accent); color: var(--on-accent); background: var(--accent); font-weight: 700; }
 button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent); background: var(--accent-hover); }
 
 .metric-grid {
@@ -695,7 +695,7 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
   box-shadow: none;
 }
 .runtime-hero-actions button:hover { border-color: var(--line-strong); background: var(--surface-hover); }
-.runtime-hero-actions button.primary { border-color: var(--accent); color: var(--on-accent); background: var(--accent); }
+.runtime-hero-actions button.primary { border-color: var(--accent); color: var(--on-accent); background: var(--accent); font-weight: 700; }
 .runtime-hero-actions button.primary:hover { border-color: var(--accent-hover); background: var(--accent-hover); }
 
 .overview-memory-panel { padding: 19px; }
@@ -902,7 +902,7 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
 .server-temperature-control strong { width: 42px; color: var(--ink-soft); font: 610 11px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace; text-align: right; }
 .server-page-footer { display: flex; align-items: center; justify-content: flex-end; gap: 14px; margin-top: 18px; }
 .server-page-footer > span { color: var(--muted-light); font-size: 11px; }
-.server-page-footer > button.primary { border-color: var(--accent); color: var(--on-accent); background: var(--accent); }
+.server-page-footer > button.primary { border-color: var(--accent); color: var(--on-accent); background: var(--accent); font-weight: 700; }
 
 /* ---------- Settings page ---------- */
 
@@ -942,7 +942,7 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
 }
 .settings-page button:hover,
 .settings-page .portable-actions label:hover { border-color: var(--line-strong); background: var(--surface-hover); }
-.settings-page button.primary { border-color: var(--accent); color: var(--on-accent); background: var(--accent); }
+.settings-page button.primary { border-color: var(--accent); color: var(--on-accent); background: var(--accent); font-weight: 700; }
 .settings-page textarea,
 .settings-page input:not([type="checkbox"]):not([type="range"]),
 .settings-page select {
@@ -1024,7 +1024,7 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
 .cluster-panel { margin-top: 10px; }
 .mcp-form { display: grid; grid-template-columns: minmax(110px, .3fr) auto minmax(240px, 1fr) auto; gap: 7px; margin-top: 12px; }
 .mcp-form input, .mcp-form select { min-width: 0; border: 1px solid var(--panel-line); border-radius: 7px; padding: 7px 9px; color: var(--ink-soft); background: var(--panel-control); font-size: 11px; }
-.mcp-form button { min-width: 64px; border: 1px solid var(--accent); border-radius: 7px; padding: 7px 11px; color: var(--on-accent); background: var(--accent); font-size: 10.5px; font-weight: 620; }
+.mcp-form button { min-width: 64px; border: 1px solid var(--accent); border-radius: 7px; padding: 7px 11px; color: var(--on-accent); background: var(--accent); font-size: 10.5px; font-weight: 700; }
 .mcp-form button:hover { border-color: var(--accent-hover); background: var(--accent-hover); }
 .mcp-server-list { display: grid; gap: 4px; margin-top: 10px; }
 .mcp-server { display: grid; grid-template-columns: auto minmax(0, 1fr) auto auto; align-items: center; gap: 8px; border-top: 1px solid var(--panel-line); padding: 8px 0; }
@@ -1088,7 +1088,7 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
   color: var(--on-accent);
   background: var(--accent);
   font-size: 11px;
-  font-weight: 650;
+  font-weight: 700;
   box-shadow: var(--shadow-sm);
 }
 .job-run:hover { border-color: var(--accent-hover); background: var(--accent-hover); transform: translateY(-1px); }
@@ -1171,7 +1171,7 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
   color: var(--on-accent);
   background: var(--accent);
   font-size: 13px;
-  font-weight: 620;
+  font-weight: 700;
   box-shadow: none;
 }
 .open-model-primary:hover { border-color: var(--accent-hover); background: var(--accent-hover); }
@@ -1283,7 +1283,7 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
 .voice-component-banner strong { font-size: 11px; }
 .voice-component-banner span { overflow: hidden; color: var(--muted); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
 .voice-component-banner progress { width: 100%; height: 4px; grid-column: 1 / -1; accent-color: var(--accent); }
-.voice-component-banner button { grid-column: 2; grid-row: 1; border: 1px solid var(--accent-border); border-radius: 7px; padding: 6px 9px; color: var(--on-accent); background: var(--accent); font-size: 10.5px; font-weight: 650; }
+.voice-component-banner button { grid-column: 2; grid-row: 1; border: 1px solid var(--accent-border); border-radius: 7px; padding: 6px 9px; color: var(--on-accent); background: var(--accent); font-size: 10.5px; font-weight: 700; }
 .voice-component-banner button:disabled { cursor: progress; opacity: 0.65; }
 .composer { overflow: hidden; border: 1px solid var(--line); border-radius: 12px; background: var(--surface); box-shadow: none; }
 .composer:focus-within { border-color: var(--line-strong); box-shadow: 0 0 0 3px var(--accent-soft); }
@@ -1296,7 +1296,7 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
 .composer-toolbar .voice-button { position: relative; width: 28px; padding: 0; border-radius: 50%; }
 .voice-button span { position: absolute; inset: 8px; border-radius: 50%; background: var(--accent); transform: scale(calc(0.82 + var(--voice-level) * 0.38)); box-shadow: 0 0 calc(4px + var(--voice-level) * 9px) var(--accent-soft); }
 .composer-hint { margin-left: auto; color: var(--muted-light); font-size: 10.5px; }
-.composer-toolbar .send-button { width: 32px; border-color: var(--accent); border-radius: 50%; padding: 0; color: var(--on-accent); background: var(--accent); }
+.composer-toolbar .send-button { width: 32px; border-color: var(--accent); border-radius: 50%; padding: 0; color: var(--on-accent); background: var(--accent); font-weight: 700; }
 .composer-toolbar .send-button:hover { border-color: var(--accent-hover); background: var(--accent-hover); }
 .composer-toolbar .send-button.stop { border-color: var(--danger); color: #fff; background: var(--danger); }
 .attachment-tray { display: flex; gap: 7px; overflow-x: auto; padding: 9px 9px 0; }

--- a/MFQStudio/src/styles.css
+++ b/MFQStudio/src/styles.css
@@ -364,7 +364,7 @@ select:focus-visible, summary:focus-visible {
   align-items: baseline;
   justify-content: space-between;
   gap: 18px;
-  margin: 25px 1px 11px;
+  margin-block: 25px 11px;
 }
 .section-label strong {
   color: var(--muted);
@@ -409,7 +409,7 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
   display: grid;
   grid-template-columns: repeat(5, minmax(0, 1fr));
   gap: 12px;
-  margin: 0;
+  margin-block: 0;
 }
 .metric-grid > .metric-tile {
   display: grid;
@@ -663,7 +663,6 @@ button.primary:hover { border-color: var(--accent-hover); color: var(--on-accent
   grid-template-columns: 54px minmax(0, 1fr) auto;
   align-items: center;
   gap: 18px;
-  margin: 0;
   padding: 20px;
 }
 .runtime-hero-copy { display: grid; min-width: 0; gap: 5px; }


### PR DESCRIPTION
## Summary

MFQ Studio's `styles.css` had grown to 2,535 lines of six partially-overriding design generations (legacy → oMLX → HiveLLM ×3 → backend-console), each redefining tokens and restyling components. The result visible on every dashboard page: content rendered on two alternating left edges (a zigzag column), 8–10px text throughout, three competing `:root` token blocks, and large sections styling markup that no longer exists (topbar, session lists, prompt grid, role dialog, lab grid).

This branch replaces the stacked layers with **one ordered design system** (2,535 → ~1,300 lines) and then fixes the UX issues the mess had been hiding. An accessibility pass grounded in Apple's HIG (computed WCAG ratios for every token/surface pair, per `apple-design-skill` guidance) closes the review.

## Commits

1. **refactor(studio): consolidate six stacked CSS design generations into one system** — one token set (light + dark + system) unified on the oMLX blue accent; only selectors the markup renders (plus the pinned `.runtime-chart polyline` contract); final cascade values preserved; dead generations removed.
2. **fix(studio): align dashboard and lab content to a single centered column** — three rules (`margin: 0` / inline margins) had overridden the shared `margin-inline: auto` centering; every Overview/Models/Server/Resources/Logs/Settings child now measures identical left/right edges.
3. **fix(studio): restore a readable type scale** — single-pass bump 8px→10px, 9px→10.5px, 10px→11px across labels, tables, logs, forms, and buttons.
4. **fix(studio): polish empty states, settings dimming, and nav noise** — idle hero renders the MFQ mark in a tile instead of an orphan "E"; the Overview "0 requests" badge only appears when requests are in flight; the settings-disabled dim eases from 0.52 to 0.65.
5. **fix(studio): meet HIG contrast minimums and macOS 10pt type floor** — `--muted-light` measured 2.76:1 (light) / 3.25:1 (dark) on panel surfaces and `--muted` 4.16:1 on canvas; new values measure ≥ 4.5:1 on every surface they render over. Labels on accent backgrounds are now weight 700 (HIG contrast table: bold text 3:1). Sidebar group labels and nav badge moved to the 10pt floor.
6. **feat(studio): press states, copy confirmation, and the settings shortcut** — global button press state per `buttons.md`; the endpoint copy button now confirms with a check icon + "Copied" for 1.6s; ⌘, opens Settings per `settings.md`.

## Verification

- `tsc -b && vite build` passes; all frontend source-contract tests pass (`test_mfq_studio_source.py`, `test_webui_scrolling.py`, `test_webui_conversation_actions.py`, `test_webui_markdown_prefill.py`, plus `test_serve_cli.py`, `test_model_capabilities.py`, chat-template source tests — 122 total).
- Every page (Overview, Models, Server, Resources, Logs, Settings, Chat) screenshot-verified in dark and light appearances and at narrow widths, before and after.

## Deliberate trade-offs

- The theme selector (system/light/dark) technically conflicts with `dark-mode.md` "avoid app-specific appearance settings", but it is pinned by `test_studio_exposes_theme_selection_without_using_sidebar_status_space` and is useful for a browser-served console, so it stays.
- The "Server idle" card sits at the sidebar bottom (`sidebars.md` cautions against critical actions there) — it is passive, duplicated status, so it stays.
- Dark-theme accent remains Apple's system blue (`--accent: #0a84ff`, pinned by tests); white-on-blue labels rely on the HIG bold-text 3:1 row rather than shifting the brand color.

No server/runtime code is touched; the diff is limited to `MFQStudio/src/App.tsx` (+27/−8) and `MFQStudio/src/styles.css` (+1,122/−2,193).