### PR TITLE
fix(quantize): keep block-scoped FFN gates quantizable under standard presets

### DIFF
--- a/mfq/quantize/standard_presets.py
+++ b/mfq/quantize/standard_presets.py
@@ -110,6 +110,9 @@ class TensorDescriptor:
 
 
 _LAYER_PATTERN = re.compile(r"(?:^|\.)(?:layers|blocks|block|blk)\.(\d+)(?:\.|$)")
+_BLOCK_FF_GATE_PATTERN = re.compile(
+    r"(?:model|vision|predictor)\.block\.\d+\.mlp\.gate\.weight"
+)
 _VISION_COMPONENTS = frozenset(
     {
         "visual",
@@ -301,9 +304,16 @@ def describe_tensor(
     is_expert_bank = len(shape) == 3 and role is TensorRole.ROUTED_EXPERT
     quantizable = (is_matrix or is_expert_bank) and source_dtype not in {"I32", "I64"}
     quantizable &= any(value.endswith(".weight") for value in names)
+    # `.mlp.gate.weight` marks a MoE router in raw checkpoints; the canonical
+    # schema maps those routers to `mlp.router.weight` and names the dense FFN
+    # gate `model.block.<N>.mlp.gate.weight`, so block-scoped gates stay
+    # quantizable and keep their fused gate/up precision pair.
+    router_gate_names = [
+        value for value in names if _BLOCK_FF_GATE_PATTERN.fullmatch(value) is None
+    ]
     quantizable &= not any(
         marker in value
-        for value in names
+        for value in router_gate_names
         for marker in (
             "_norm.weight",
             "layernorm.weight",


### PR DESCRIPTION
## Problem

Every standard preset (`S2-S8`) fails for dense Qwen3.5-style checkpoints with:

```
ValueError: runtime-fused gate/up tensors must share one precision layout:
model.block.0.mlp.gate.weight=('BF16',), model.block.0.mlp.up.weight=('NINT', 4, 24, 6)
```

Reproduce: `uv run mfq quantize Qwen/Qwen3.5-0.8B out.mfq --preset S4-M`

## Root cause

The `.mlp.gate.weight` never-quantize marker in `describe_tensor` exists for **raw MoE router** tensors (Qwen3/GLM-style `model.layers.N.mlp.gate.weight`). Since b1d3dea9 the marker list is matched against canonical names as well, and the canonical schema names the dense FFN gate exactly `model.block.N.mlp.gate.weight` (mapped from HF `mlp.gate_proj.weight`). So every dense FFN gate was pinned to BF16 while its fused `mlp.up` partner quantized, and `_validate_runtime_fused_pairs` correctly rejected the resulting plan.

## Fix

Exempt `(model|vision|predictor).block.<N>.mlp.gate.weight` from the router marker so block-scoped FFN gates stay quantizable and keep their fused gate/up precision pair.

- Raw source routers (`model.layers.N.mlp.gate.weight`) still match the marker and stay dense.
- Schema-mapped routers are unaffected: they canonicalize to `mlp.router.weight`, which is already dense via the `router` dense component.
- Already-canonical sources (full-precision MFQ re-quantization) now quantize correctly too.

## Verification

- `mfq quantize --preset S4-M` on `Qwen/Qwen3.5-0.8B` (HF source) completes; the artifact's per-tensor error norms are normal (~6.7% NINT4 / ~1.7% NINT6) and greedy generation matches the BF16 baseline in the MLX runtime.
- `tests/test_tensor_schema.py`, `tests/test_tensor_schema_extended.py`, `tests/test_quantize/`: 410 passed, 55 skipped.

## Out of scope (separate issue)

While validating the artifact I found the native Metal runtime (`mfq-decode-metal`) corrupts output for **NINT bits=4** on qwen3_5 (wrong answers/repetition loops) while NINT6/NINT8 are correct, and the same NINT4 container is correct through the Python/MLX runtime — bisected across uniform/preset plans, groupsize 16/24, and sub-bits 5/6. The 4-bit branches in `cpp_runtime/backends/metal/kernels/mfq_nintm_prefill.metal` (and/or their C++ marshalling) look suspect; `qwen35_real_layer_smoke.cpp` is not registered in CMake, so nothing currently catches this.